### PR TITLE
[harness] Add manual GitHub Pages workflow and deploy docs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,70 @@
+name: Deploy GitHub Pages
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Require default branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "${{ github.event.repository.default_branch }}" ]; then
+            echo "This workflow only deploys from the default branch."
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ark-str-web-app/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install app dependencies
+        working-directory: ark-str-web-app
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Verify repository and exported site
+        run: npm run verify
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ark-str-web-app/out
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ npm run content:check
 npm run verify
 ```
 
+## Deploy To GitHub Pages
+
+The repository publishes a static export to project pages at `https://wjlee611.github.io/ark-str/`.
+
+Before the first deployment, set the repository Pages source to `GitHub Actions` in `Settings -> Pages`.
+
+Manual deployment flow:
+
+```bash
+npm run verify
+npm --prefix ark-str-web-app run export:ghpages
+```
+
+Then open the Actions tab and run the `Deploy GitHub Pages` workflow manually from `main`.
+
+The workflow rebuilds the app, runs `npm run verify`, uploads `ark-str-web-app/out`, and deploys that exported artifact to GitHub Pages.
+
 ## Root Harness Commands
 
 - `npm run guards:all`
@@ -55,7 +72,7 @@ npm run verify
 
 ## Current Phase
 
-The repository is in the dev-startup regression-recovery phase after the first reader iteration:
+The repository is in the manual Pages deployment enablement phase after the first reader iteration:
 
 - nested app scaffold and root harness split are complete
 - editorial archive theme tokens and shared UI primitives are established
@@ -63,4 +80,5 @@ The repository is in the dev-startup regression-recovery phase after the first r
 - app-internal generated metadata under `ark-str-web-app/src/generated/content/` keep the reader export-safe without mirroring full story payloads into app source
 - `npm run dev` uses an isolated `.next-dev` cache and export verification uses `.next-export`, so verify no longer poisons the next local dev startup
 - `npm run verify` now validates the exported site with Playwright against the `/ark-str/` subpath
+- a manual `Deploy GitHub Pages` workflow can publish the exported artifact through GitHub Actions
 - summary generation and character unlock extraction remain follow-up work

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -16,12 +16,14 @@ Every meaningful change should pass:
 
 - The app must build without runtime network access after dependencies are installed.
 - The app must export successfully for the gh-pages `/ark-str/` base path.
+- The repository must provide a manual GitHub Pages deployment workflow that rebuilds and verifies before publishing `ark-str-web-app/out`.
 - The app must keep dev-cache and export-cache output isolated so `npm run verify` does not slow the next `npm run dev`.
 - The app must render without requiring a server-side data source.
 - Persisted state must survive a refresh and recover safely from malformed `localStorage` values.
 - Browser smoke must complete with no uncaught page errors.
 - Browser smoke must complete with no `console.error` output.
 - Browser smoke must exercise the exported site, not a `next start` server.
+- Any Pages deployment workflow must publish only an artifact produced after `npm run verify` succeeds.
 - Design-system guard checks must reject hard-coded runtime colors outside the token source.
 - Content integrity checks must reject drift between committed generated outputs and the current vendor source when the submodule is available.
 - Harness orchestration logic must pass its unit tests before an iteration can be reported as successful.

--- a/docs/exec-plans/active/pages-deployment-workflow.md
+++ b/docs/exec-plans/active/pages-deployment-workflow.md
@@ -1,0 +1,62 @@
+# Pages Deployment Workflow
+
+Status: active
+Owner: Codex
+Started: 2026-04-16
+Parent issue: `#15`
+Active child issue: `#16`
+Draft PR: pending
+
+## Objective
+
+Add a manual GitHub Pages deployment workflow that publishes the exported app artifact and document the operational flow from local verify through manual dispatch.
+
+## Scope
+
+- add a `workflow_dispatch` GitHub Actions workflow for Pages deployment
+- keep `ark-str-web-app/out` as the exported artifact contract
+- document repository settings and manual deployment steps
+- refresh iteration records after the deployment workflow is merged
+
+## Constraints
+
+- keep GitHub Pages deployment manual-only for this iteration
+- keep `/ark-str/` as the published base path
+- do not add a `gh-pages` branch deployment flow
+- keep `npm run verify` as the deployment quality gate
+
+## Issue And PR Dependency Graph
+
+- `#16 deployment-workflow-and-docs`
+  - depends on: none
+  - PR: pending
+
+## Commit Policy
+
+- first milestone: scaffold the active plan and issue metadata
+- second milestone: add the deployment workflow and docs changes
+- final milestone: refresh iteration records, apply review fixes, and close the iteration
+
+Commit format:
+
+- `milestone(issue-16): scaffold`
+- `milestone(issue-16): core`
+- `chore(issue-16): ...`
+- `fix(issue-16): ...`
+
+## Tasks
+
+- [ ] add the active deployment plan and open the child PR
+- [ ] add `.github/workflows/deploy-pages.yml` for manual GitHub Pages deployment
+- [ ] update README and reliability docs with the manual deployment flow
+- [ ] refresh product/quality/iteration docs after verification and merge
+
+## Verification
+
+- `npm run verify`
+- `npm --prefix ark-str-web-app run export:ghpages`
+
+## Decision Log
+
+- 2026-04-16: Use GitHub Actions Pages deployment with `workflow_dispatch` only.
+- 2026-04-16: Keep the published base path fixed at `/ark-str/` for project-pages deployment.

--- a/docs/exec-plans/active/pages-deployment-workflow.md
+++ b/docs/exec-plans/active/pages-deployment-workflow.md
@@ -5,7 +5,7 @@ Owner: Codex
 Started: 2026-04-16
 Parent issue: `#15`
 Active child issue: `#16`
-Draft PR: pending
+Draft PR: `#17`
 
 ## Objective
 

--- a/docs/exec-plans/completed/pages-deployment-workflow.md
+++ b/docs/exec-plans/completed/pages-deployment-workflow.md
@@ -1,6 +1,6 @@
 # Pages Deployment Workflow
 
-Status: active
+Status: completed
 Owner: Codex
 Started: 2026-04-16
 Parent issue: `#15`
@@ -29,7 +29,7 @@ Add a manual GitHub Pages deployment workflow that publishes the exported app ar
 
 - `#16 deployment-workflow-and-docs`
   - depends on: none
-  - PR: pending
+  - PR: `#17`
 
 ## Commit Policy
 
@@ -46,10 +46,10 @@ Commit format:
 
 ## Tasks
 
-- [ ] add the active deployment plan and open the child PR
-- [ ] add `.github/workflows/deploy-pages.yml` for manual GitHub Pages deployment
-- [ ] update README and reliability docs with the manual deployment flow
-- [ ] refresh product/quality/iteration docs after verification and merge
+- [x] add the active deployment plan and open the child PR
+- [x] add `.github/workflows/deploy-pages.yml` for manual GitHub Pages deployment
+- [x] update README and reliability docs with the manual deployment flow
+- [x] refresh product/quality/iteration docs after verification and merge
 
 ## Verification
 
@@ -60,3 +60,4 @@ Commit format:
 
 - 2026-04-16: Use GitHub Actions Pages deployment with `workflow_dispatch` only.
 - 2026-04-16: Keep the published base path fixed at `/ark-str/` for project-pages deployment.
+- 2026-04-16: Run the workflow only from `main` so manual dispatch cannot publish a non-default branch by accident.

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,17 +1,17 @@
 # Latest Iteration
 
-Latest parent iteration: `#12`
+Latest parent iteration: `#15`
 
 Merged child issues:
 
-- `#13` via PR `#14` - dev-startup regression recovery for generated loaders and cache separation
+- `#16` via PR `#17` - manual GitHub Pages deployment workflow and deployment docs
 
 Current closeout outcome:
 
-- `public/generated/content/` remains the published bundled content contract for full story payloads
-- `ark-str-web-app/src/generated/content/` now contains metadata-only loader artifacts instead of mirroring the full story corpus
-- `npm run dev` uses `.next-dev` and export verification uses `.next-export`, so verify no longer poisons the next local dev startup
-- `npm run verify` still validates the gh-pages `/ark-str/` export path with Playwright
+- the repository ships a manual `Deploy GitHub Pages` workflow that rebuilds, verifies, and publishes `ark-str-web-app/out`
+- the Pages deployment path remains aligned with the `/ark-str/` export-safe app contract
+- deployment instructions now live in the repository docs instead of relying on local knowledge
+- `npm run verify` remains the required gate before any published artifact is uploaded
 
 Remaining product gaps:
 

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -1,7 +1,7 @@
 # Arknights Story Reader
 
 Status: active
-Phase: dev-startup recovery
+Phase: manual Pages deployment enablement
 
 ## Product Goal
 
@@ -43,7 +43,7 @@ Build a web application that makes Arknights story content easier to read, summa
 
 ## Current Phase
 
-This phase removes the dev-startup regression introduced after the first reader iteration. It keeps:
+This phase keeps the recovered reader shell stable while adding a repeatable manual GitHub Pages deployment path. It keeps:
 
 - canonical locale URLs at `/reader/[locale]` and `/reader/[locale]/[groupId]/[storyId]`
 - generated story detail files under `public/generated/content/stories/`
@@ -53,3 +53,4 @@ This phase removes the dev-startup regression introduced after the first reader 
 - explicit empty summary state until the summary-generation issue lands
 - gh-pages-safe static export under the `/ark-str/` base path
 - isolated `.next-dev` and `.next-export` caches so `npm run verify` does not degrade the next `npm run dev` startup
+- a manual GitHub Actions Pages workflow that rebuilds, verifies, and publishes `ark-str-web-app/out`


### PR DESCRIPTION
## Summary\n- add a manual GitHub Pages deployment workflow for the exported app\n- document the Pages settings and manual deploy flow\n- refresh iteration records for the new deployment iteration\n\n## Issue\n- closes #16\n- parent #15\n