### PR TITLE
[harness] Align Pages artifact contract with actual export output

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: ark-str-web-app/out
+          path: ark-str-web-app/.next-export
 
   deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm --prefix ark-str-web-app run export:ghpages
 
 Then open the Actions tab and run the `Deploy GitHub Pages` workflow manually from `main`.
 
-The workflow rebuilds the app, runs `npm run verify`, uploads `ark-str-web-app/out`, and deploys that exported artifact to GitHub Pages.
+The workflow rebuilds the app, runs `npm run verify`, uploads `ark-str-web-app/.next-export`, and deploys that exported artifact to GitHub Pages.
 
 ## Root Harness Commands
 

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -16,7 +16,7 @@ Every meaningful change should pass:
 
 - The app must build without runtime network access after dependencies are installed.
 - The app must export successfully for the gh-pages `/ark-str/` base path.
-- The repository must provide a manual GitHub Pages deployment workflow that rebuilds and verifies before publishing `ark-str-web-app/out`.
+- The repository must provide a manual GitHub Pages deployment workflow that rebuilds and verifies before publishing `ark-str-web-app/.next-export`.
 - The app must keep dev-cache and export-cache output isolated so `npm run verify` does not slow the next `npm run dev`.
 - The app must render without requiring a server-side data source.
 - Persisted state must survive a refresh and recover safely from malformed `localStorage` values.

--- a/docs/exec-plans/active/pages-deployment-follow-up-fix.md
+++ b/docs/exec-plans/active/pages-deployment-follow-up-fix.md
@@ -4,47 +4,52 @@ Status: active
 Owner: Codex
 Started: 2026-04-16
 Parent issue: `#18`
-Active child issue: `#19`
-Draft PR: `#20`
+Active child issue: `#21`
+Draft PR: pending
 
 ## Objective
 
-Repair the exported-site path handling so the GitHub Pages workflow can complete its CI verify step and publish successfully.
+Repair the exported artifact contract so the GitHub Pages workflow and exported-site smoke both use the real static export directory and can publish successfully.
 
 ## Scope
 
-- make app config resolve its root from the app directory rather than the caller cwd
+- align smoke preview and Pages upload with the actual `ark-str-web-app/.next-export` output
 - re-run the manual Pages workflow after the fix merges
 - close the follow-up iteration after a successful deployment run
 
 ## Constraints
 
-- keep the existing `ark-str-web-app/out` artifact contract
-- do not change the `/ark-str/` base path
+- keep `/ark-str/` as the published base path
+- treat `ark-str-web-app/.next-export` as the actual exported artifact contract for build verification and Pages upload
 - keep `npm run verify` as the required deployment gate
 
 ## Issue And PR Dependency Graph
 
-- `#19 deployment-workflow-follow-up-fix`
+- `#19 config-root-fix`
   - depends on: none
+  - PR: `#20`
+- `#21 export-artifact-contract-fix`
+  - depends on: `#19`
   - PR: pending
 
 ## Commit Policy
 
 - first milestone: scaffold the follow-up fix plan
-- second milestone: fix app-root resolution for export output
+- second milestone: align smoke and deployment with the actual exported artifact path
 - final milestone: close the plan and record the successful deployment rerun
 
 Commit format:
 
 - `milestone(issue-19): scaffold`
-- `fix(issue-19): ...`
+- `fix(issue-21): ...`
 - `chore(issue-19): ...`
 
 ## Tasks
 
-- [ ] open the follow-up plan and child PR
-- [ ] fix root-driven export output path handling
+- [x] open the follow-up plan and child PR
+- [x] fix root-driven export output path handling
+- [ ] open the second child PR for the export artifact contract fix
+- [ ] align smoke preview and workflow upload with `ark-str-web-app/.next-export`
 - [ ] rerun `npm run verify`
 - [ ] rerun the `Deploy GitHub Pages` workflow successfully
 
@@ -56,3 +61,4 @@ Commit format:
 ## Decision Log
 
 - 2026-04-16: Treat the first failed deployment as a follow-up fix iteration rather than force-pushing changes into the merged deployment PR history.
+- 2026-04-16: The real static export output lives in `ark-str-web-app/.next-export`, so the smoke server and Pages workflow must use that path instead of a stale `out/` directory.

--- a/scripts/harness/serve-export-preview.mjs
+++ b/scripts/harness/serve-export-preview.mjs
@@ -6,7 +6,7 @@ const host = process.env.SMOKE_HOST ?? "127.0.0.1";
 const port = Number.parseInt(process.env.SMOKE_PORT ?? "3200", 10);
 const appBasePath = (process.env.PLAYWRIGHT_APP_BASE_PATH ?? "/ark-str").replace(/^\/+|\/+$/g, "");
 const repoRoot = process.cwd();
-const exportRoot = path.join(repoRoot, "ark-str-web-app", "out");
+const exportRoot = path.join(repoRoot, "ark-str-web-app", ".next-export");
 const previewRoot = path.join(
   repoRoot,
   "artifacts",
@@ -17,7 +17,7 @@ const previewAppRoot = path.join(previewRoot, appBasePath);
 
 function ensurePreviewTree() {
   if (!fs.existsSync(exportRoot)) {
-    throw new Error("ark-str-web-app/out is missing. Run `npm run app:verify` before smoke.");
+    throw new Error("ark-str-web-app/.next-export is missing. Run `npm run app:verify` before smoke.");
   }
 
   fs.mkdirSync(path.dirname(previewAppRoot), { recursive: true });


### PR DESCRIPTION
## Summary\n- point exported-site smoke at the real static export directory\n- upload the real export artifact in the Pages workflow\n- update deployment docs to match the actual artifact contract\n\n## Issue\n- closes #21\n- parent #18\n