### PR TITLE
[harness] Close deployment follow-up iteration docs and records

### DIFF
--- a/docs/exec-plans/completed/pages-deployment-follow-up-fix.md
+++ b/docs/exec-plans/completed/pages-deployment-follow-up-fix.md
@@ -1,15 +1,15 @@
 # Pages Deployment Follow-Up Fix
 
-Status: active
+Status: completed
 Owner: Codex
 Started: 2026-04-16
 Parent issue: `#18`
-Active child issue: `#21`
+Active child issue: `#23`
 Draft PR: pending
 
 ## Objective
 
-Repair the exported artifact contract so the GitHub Pages workflow and exported-site smoke both use the real static export directory and can publish successfully.
+Repair the Pages deployment workflow after the first failed run, then close the follow-up deployment iteration after a successful rerun.
 
 ## Scope
 
@@ -30,6 +30,9 @@ Repair the exported artifact contract so the GitHub Pages workflow and exported-
   - PR: `#20`
 - `#21 export-artifact-contract-fix`
   - depends on: `#19`
+  - PR: `#22`
+- `#23 iteration-closeout`
+  - depends on: `#19`, `#21`
   - PR: pending
 
 ## Commit Policy
@@ -42,16 +45,16 @@ Commit format:
 
 - `milestone(issue-19): scaffold`
 - `fix(issue-21): ...`
-- `chore(issue-19): ...`
+- `chore(issue-23): ...`
 
 ## Tasks
 
 - [x] open the follow-up plan and child PR
 - [x] fix root-driven export output path handling
-- [ ] open the second child PR for the export artifact contract fix
-- [ ] align smoke preview and workflow upload with `ark-str-web-app/.next-export`
-- [ ] rerun `npm run verify`
-- [ ] rerun the `Deploy GitHub Pages` workflow successfully
+- [x] open the second child PR for the export artifact contract fix
+- [x] align smoke preview and workflow upload with `ark-str-web-app/.next-export`
+- [x] rerun `npm run verify`
+- [x] rerun the `Deploy GitHub Pages` workflow successfully
 
 ## Verification
 
@@ -62,3 +65,4 @@ Commit format:
 
 - 2026-04-16: Treat the first failed deployment as a follow-up fix iteration rather than force-pushing changes into the merged deployment PR history.
 - 2026-04-16: The real static export output lives in `ark-str-web-app/.next-export`, so the smoke server and Pages workflow must use that path instead of a stale `out/` directory.
+- 2026-04-16: Keep the Node 20 GitHub Actions deprecation notice as a documented follow-up since it does not block the successful manual Pages deployment.

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,16 +1,19 @@
 # Latest Iteration
 
-Latest parent iteration: `#15`
+Latest parent iteration: `#18`
 
 Merged child issues:
 
-- `#16` via PR `#17` - manual GitHub Pages deployment workflow and deployment docs
+- `#19` via PR `#20` - fix app-root resolution for root-driven export verification
+- `#21` via PR `#22` - align smoke preview and Pages upload with the actual export artifact
+- `#23` via PR `#24` - close deployment follow-up docs and iteration records
 
 Current closeout outcome:
 
-- the repository ships a manual `Deploy GitHub Pages` workflow that rebuilds, verifies, and publishes `ark-str-web-app/out`
-- the Pages deployment path remains aligned with the `/ark-str/` export-safe app contract
-- deployment instructions now live in the repository docs instead of relying on local knowledge
+- the repository ships a manual `Deploy GitHub Pages` workflow that rebuilds, verifies, and publishes `ark-str-web-app/.next-export`
+- the workflow succeeded on `main` in run `#24504983628`
+- exported-site smoke now reads the real static export directory instead of relying on a stale local `out/` folder
+- deployment instructions and follow-up plan records now match the actual GitHub Pages artifact contract
 - `npm run verify` remains the required gate before any published artifact is uploaded
 
 Remaining product gaps:
@@ -18,3 +21,4 @@ Remaining product gaps:
 - story summaries are not generated yet
 - character unlock extraction is not implemented yet
 - portrait asset integration is still placeholder-based
+- GitHub Actions still emits a non-blocking Node 20 deprecation warning for the official Pages actions versions currently in use


### PR DESCRIPTION
## Summary\n- move the deployment follow-up plan to completed\n- update latest iteration with the successful Pages rerun\n- close the still-open deployment parent iteration after merge\n\n## Issue\n- closes #23\n- parent #18\n