### PR TITLE
[harness] Refresh reader background previews and modernized chrome

### DIFF
--- a/ark-str-web-app/src/app/globals.css
+++ b/ark-str-web-app/src/app/globals.css
@@ -15,8 +15,12 @@
   --ring: rgba(180, 93, 61, 0.24);
   --success: #56755a;
   --warning: #8b6238;
-  --font-display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif;
-  --font-body: "Avenir Next", "Segoe UI", "Apple SD Gothic Neo", sans-serif;
+  --font-display:
+    Inter, "SF Pro Display", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Helvetica Neue",
+    Arial, sans-serif;
+  --font-body:
+    Inter, "SF Pro Text", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Helvetica Neue",
+    Arial, sans-serif;
   --font-mono: "SFMono-Regular", "SF Mono", "Cascadia Code", "JetBrains Mono", monospace;
   --space-1: 0.25rem;
   --space-2: 0.5rem;
@@ -26,15 +30,15 @@
   --space-6: 2rem;
   --space-7: 3rem;
   --space-8: 4rem;
-  --radius-sm: 0.625rem;
-  --radius-md: 0.875rem;
-  --radius-lg: 1.25rem;
-  --radius-xl: 1.75rem;
-  --shadow-sm: 0 10px 22px rgba(28, 42, 54, 0.08);
-  --shadow-md: 0 22px 54px rgba(28, 42, 54, 0.12);
-  --shadow-lg: 0 32px 72px rgba(28, 42, 54, 0.18);
+  --radius-sm: 0.425rem;
+  --radius-md: 0.7rem;
+  --radius-lg: 0.95rem;
+  --radius-xl: 1.2rem;
+  --shadow-sm: 0 8px 18px rgba(28, 42, 54, 0.07);
+  --shadow-md: 0 18px 42px rgba(28, 42, 54, 0.11);
+  --shadow-lg: 0 26px 64px rgba(28, 42, 54, 0.16);
   --motion-fast: 160ms;
-  --motion-base: 240ms;
+  --motion-base: 260ms;
 }
 
 html[data-theme="dark"] {
@@ -79,6 +83,7 @@ body {
   background: transparent;
   color: var(--text);
   font-family: var(--font-body);
+  letter-spacing: -0.011em;
   transition:
     background-color var(--motion-base) ease,
     color var(--motion-base) ease;
@@ -109,10 +114,28 @@ textarea {
 }
 
 .story-backdrop-overlay {
-  background: color-mix(in srgb, var(--bg) 64%, transparent);
-  opacity: 0.7;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--bg) 46%, transparent) 0%, color-mix(in srgb, var(--bg) 80%, transparent) 100%),
+    color-mix(in srgb, var(--bg) 42%, transparent);
+  opacity: 0.82;
 }
 
 .story-backdrop-highlight {
-  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.16), transparent 38%);
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.14), transparent 34%);
+}
+
+.story-backdrop-media {
+  transition:
+    opacity var(--motion-base) ease,
+    transform calc(var(--motion-base) + 80ms) ease;
+}
+
+.story-backdrop-media[data-state="inactive"] {
+  opacity: 0;
+  transform: scale(1.03);
+}
+
+.story-backdrop-media[data-state="active"] {
+  opacity: 1;
+  transform: scale(1);
 }

--- a/ark-str-web-app/src/components/layout/floating-app-bar.tsx
+++ b/ark-str-web-app/src/components/layout/floating-app-bar.tsx
@@ -44,7 +44,7 @@ export function FloatingAppBar({ model }: FloatingAppBarProps) {
 
   return (
     <div
-      className="sticky top-4 z-40 rounded-[calc(var(--radius-xl)+0.25rem)] border border-[var(--border)] bg-[var(--surface)]/82 px-3 py-3 shadow-[var(--shadow-lg)] backdrop-blur-xl"
+      className="sticky top-4 z-40 rounded-[var(--radius-xl)] border border-[var(--border)] bg-[var(--surface)]/78 px-4 py-3 shadow-[var(--shadow-md)] backdrop-blur-xl"
       data-testid="floating-app-bar"
     >
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -78,7 +78,7 @@ export function FloatingAppBar({ model }: FloatingAppBarProps) {
               <span className="px-1 text-sm text-[var(--text-muted)]">&gt;</span>
               <div className="min-w-[15rem] flex-1 lg:min-w-[20rem]">
                 <Select
-                  className="h-9 rounded-[var(--radius-md)] bg-[var(--surface)]/92 py-0 text-sm shadow-none"
+                  className="h-10 rounded-[var(--radius-md)] bg-[var(--surface)]/92 py-0 text-sm shadow-none"
                   data-testid="chrome-story-select"
                   onChange={handleStoryChange}
                   value={model.storySelect.currentStoryId}
@@ -97,7 +97,7 @@ export function FloatingAppBar({ model }: FloatingAppBarProps) {
         <div className="flex flex-wrap items-center gap-2 lg:justify-end">
           <div className="min-w-[10rem]">
             <Select
-              className="h-9 rounded-[var(--radius-md)] bg-[var(--surface)]/92 py-0 text-sm shadow-none"
+              className="h-10 rounded-[var(--radius-md)] bg-[var(--surface)]/92 py-0 text-sm shadow-none"
               data-testid="locale-select"
               disabled={!isSessionHydrated}
               onChange={handleLocaleChange}

--- a/ark-str-web-app/src/components/ui/badge.tsx
+++ b/ark-str-web-app/src/components/ui/badge.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em]",
+  "inline-flex items-center rounded-[var(--radius-sm)] border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]",
   {
     variants: {
       variant: {

--- a/ark-str-web-app/src/components/ui/button.tsx
+++ b/ark-str-web-app/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-md)] border px-4 py-2.5 text-sm font-semibold shadow-[var(--shadow-sm)] transition duration-[var(--motion-fast)] ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-md)] border px-4 py-2.5 text-sm font-semibold tracking-[-0.012em] shadow-[var(--shadow-sm)] transition duration-[var(--motion-fast)] ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/ark-str-web-app/src/components/ui/card.tsx
+++ b/ark-str-web-app/src/components/ui/card.tsx
@@ -5,7 +5,7 @@ function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn(
-        "rounded-[var(--radius-xl)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow-md)]",
+        "rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--surface)] shadow-[var(--shadow-md)]",
         className,
       )}
       data-slot="card"
@@ -21,7 +21,10 @@ function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement
 function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h2
-      className={cn("text-balance text-xl text-[var(--text)] [font-family:var(--font-display)]", className)}
+      className={cn(
+        "text-balance text-xl font-semibold tracking-[-0.024em] text-[var(--text)] [font-family:var(--font-display)]",
+        className,
+      )}
       data-slot="card-title"
       {...props}
     />

--- a/ark-str-web-app/src/components/ui/select.tsx
+++ b/ark-str-web-app/src/components/ui/select.tsx
@@ -9,7 +9,7 @@ function Select({ className, children, ...props }: SelectProps) {
     <div className="relative" data-slot="select-root">
       <select
         className={cn(
-          "h-12 w-full appearance-none rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--surface)] px-4 pr-11 text-sm text-[var(--text)] shadow-[var(--shadow-sm)] outline-none transition duration-[var(--motion-fast)] ease-out focus-visible:border-[var(--accent)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60",
+          "h-11 w-full appearance-none rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface)] px-4 pr-11 text-sm tracking-[-0.012em] text-[var(--text)] shadow-[var(--shadow-sm)] outline-none transition duration-[var(--motion-fast)] ease-out focus-visible:border-[var(--accent)] focus-visible:ring-2 focus-visible:ring-[var(--ring)] disabled:cursor-not-allowed disabled:opacity-60",
           className,
         )}
         data-slot="select"

--- a/ark-str-web-app/src/features/bootstrap/ui/bootstrap-home.tsx
+++ b/ark-str-web-app/src/features/bootstrap/ui/bootstrap-home.tsx
@@ -82,7 +82,7 @@ export function BootstrapHome({
             <CardHeader className="gap-4 pb-0">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <Badge variant="accent">Reader shell</Badge>
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   Editorial archive surface
                 </p>
               </div>
@@ -97,7 +97,7 @@ export function BootstrapHome({
             <CardContent className="grid gap-6 pt-6">
               <div className="grid gap-4 lg:grid-cols-3">
                 <div className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--surface-muted)] p-4">
-                  <p className="text-xs uppercase tracking-[0.22em] text-[var(--text-muted)]">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                     Continue
                   </p>
                   <p className="mt-2 text-lg font-semibold">
@@ -108,14 +108,16 @@ export function BootstrapHome({
                   </p>
                 </div>
                 <div className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--surface-muted)] p-4">
-                  <p className="text-xs uppercase tracking-[0.22em] text-[var(--text-muted)]">Scope</p>
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                    Scope
+                  </p>
                   <p className="mt-2 text-lg font-semibold">Body-first reader</p>
                   <p className="mt-1 text-sm leading-6 text-[var(--text-muted)]">
                     summary는 아직 생성되지 않았으므로, 하단 section에서 explicit empty state로만 노출합니다.
                   </p>
                 </div>
                 <div className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--surface-muted)] p-4">
-                  <p className="text-xs uppercase tracking-[0.22em] text-[var(--text-muted)]">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                     Locale set
                   </p>
                   <p className="mt-2 text-lg font-semibold">cn / en / jp / kr / tw</p>
@@ -147,7 +149,7 @@ export function BootstrapHome({
                 className="rounded-[var(--radius-xl)] border border-[var(--border)] bg-[var(--panel)] p-5"
                 data-testid="last-visited-story"
               >
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   Last visited
                 </p>
                 {state.lastVisitedStory ? (
@@ -182,19 +184,19 @@ export function BootstrapHome({
             <CardContent className="grid gap-5">
               <dl className="grid gap-4 sm:grid-cols-3">
                 <div>
-                  <dt className="uppercase tracking-[0.18em] text-[var(--text-muted)]">Vendor servers</dt>
+                  <dt className="uppercase tracking-[0.14em] text-[var(--text-muted)]">Vendor servers</dt>
                   <dd className="mt-1 text-base font-semibold">
                     <span data-testid="server-count">{readiness.serverCount}</span>
                   </dd>
                 </div>
                 <div>
-                  <dt className="uppercase tracking-[0.18em] text-[var(--text-muted)]">Reader stories</dt>
+                  <dt className="uppercase tracking-[0.14em] text-[var(--text-muted)]">Reader stories</dt>
                   <dd className="mt-1 text-base font-semibold">
                     <span data-testid="story-count">{readiness.storyCount}</span>
                   </dd>
                 </div>
                 <div>
-                  <dt className="uppercase tracking-[0.18em] text-[var(--text-muted)]">Missing summaries</dt>
+                  <dt className="uppercase tracking-[0.14em] text-[var(--text-muted)]">Missing summaries</dt>
                   <dd className="mt-1 text-base font-semibold">
                     <span data-testid="summary-missing-count">{readiness.summaryMissingCount}</span>
                   </dd>
@@ -202,7 +204,7 @@ export function BootstrapHome({
               </dl>
               <Separator />
               <div className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)] p-4">
-                <p className="text-xs uppercase tracking-[0.2em] text-[var(--text-muted)]">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   Build snapshot
                 </p>
                 <p className="mt-2 text-sm leading-7 text-[var(--text-muted)]">
@@ -306,7 +308,7 @@ export function BootstrapHome({
                   className="grid gap-3 rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)] p-4"
                 >
                   <div className="flex items-center gap-3">
-                    <span className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface)]">
+                    <span className="inline-flex h-10 w-10 items-center justify-center rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface)]">
                       <step.icon className="h-4 w-4 text-[var(--accent)]" />
                     </span>
                     <div>

--- a/ark-str-web-app/src/features/reader/ui/reader-group-overview.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-group-overview.tsx
@@ -31,7 +31,7 @@ export function ReaderGroupOverview({
             <Badge variant="accent" className="w-fit">
               Group overview
             </Badge>
-            <h1 className="font-[var(--font-display)] text-4xl leading-tight md:text-5xl">
+            <h1 className="font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.03em] md:text-5xl">
               {group.title}
             </h1>
             <p className="max-w-3xl text-sm leading-7 text-[var(--text-muted)] md:text-base">

--- a/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
@@ -29,7 +29,7 @@ export function ReaderLocaleArchive({
             <Badge variant="accent" className="w-fit">
               Locale archive
             </Badge>
-            <h1 className="font-[var(--font-display)] text-4xl leading-tight md:text-5xl">
+            <h1 className="font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.03em] md:text-5xl">
               {READER_LOCALE_LABELS[locale].label}
             </h1>
             <p className="max-w-3xl text-sm leading-7 text-[var(--text-muted)] md:text-base">
@@ -38,7 +38,9 @@ export function ReaderLocaleArchive({
           </div>
           <Card className="min-w-48 bg-[var(--surface)]/90">
             <CardContent className="px-5 py-4 text-right">
-              <p className="text-xs uppercase tracking-[0.2em] text-[var(--text-muted)]">Groups</p>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                Groups
+              </p>
               <p className="mt-2 text-3xl font-semibold text-[var(--text)]">{groups.length}</p>
             </CardContent>
           </Card>
@@ -50,17 +52,17 @@ export function ReaderLocaleArchive({
         {groups.map((group) => (
           <Card key={group.groupId} className="bg-[var(--surface)]/95">
             <CardHeader>
-              <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                 {group.entryType ?? "GROUP"}
               </p>
-              <CardTitle className="font-[var(--font-display)] text-3xl">{group.title}</CardTitle>
+              <CardTitle className="text-3xl">{group.title}</CardTitle>
               <CardDescription>
                 {group.storyCount} stories{group.actType ? ` · ${group.actType}` : ""}
               </CardDescription>
             </CardHeader>
             <CardContent className="grid gap-4">
               <div className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)] p-4">
-                <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                   Group preview
                 </p>
                 {group.stories[0] ? (

--- a/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
@@ -33,7 +33,7 @@ function ReaderPortraitSlot({
 }) {
   return (
     <div
-      className="flex h-20 w-16 shrink-0 items-start justify-center overflow-hidden rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface-muted)]"
+      className="flex h-20 w-16 shrink-0 items-start justify-center overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)]"
       data-testid="speaker-portrait-slot"
     >
       {portraitPath ? (
@@ -123,17 +123,69 @@ function collectBackgroundSequenceFromBlocks(blocks: StoryBlock[], accumulator: 
 }
 
 function StoryBackdrop({ backgroundPath }: { backgroundPath: string | null }) {
+  const [committedPath, setCommittedPath] = useState<string | null>(backgroundPath);
+  const [incomingPath, setIncomingPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (backgroundPath === committedPath) {
+      return;
+    }
+
+    let timeoutId: number | null = null;
+    const rafId = window.requestAnimationFrame(() => {
+      if (!backgroundPath) {
+        setCommittedPath(null);
+        setIncomingPath(null);
+        return;
+      }
+
+      if (!committedPath) {
+        setCommittedPath(backgroundPath);
+        setIncomingPath(null);
+        return;
+      }
+
+      setIncomingPath(backgroundPath);
+      timeoutId = window.setTimeout(() => {
+        setCommittedPath(backgroundPath);
+        setIncomingPath(null);
+      }, 320);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [backgroundPath, committedPath]);
+
+  const resolvedPath = incomingPath ?? committedPath;
+
   return (
     <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden" data-testid="story-backdrop">
-      {backgroundPath ? (
+      {resolvedPath ? (
         <>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            alt=""
-            aria-hidden="true"
-            className="absolute inset-0 h-full w-full scale-105 object-cover object-center blur-xl"
-            src={backgroundPath}
-          />
+          {committedPath ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt=""
+              aria-hidden="true"
+              className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
+              data-state={incomingPath ? "inactive" : "active"}
+              src={committedPath}
+            />
+          ) : null}
+          {incomingPath ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt=""
+              aria-hidden="true"
+              className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
+              data-state="active"
+              src={incomingPath}
+            />
+          ) : null}
           <div className="story-backdrop-overlay absolute inset-0" />
           <div className="story-backdrop-highlight absolute inset-0" />
         </>
@@ -183,26 +235,64 @@ function StoryBackgroundMarker({
   return (
     <article
       ref={markerRef}
-      className={`rounded-[var(--radius-lg)] border p-4 ${
+      className={`overflow-hidden rounded-[var(--radius-lg)] border p-4 shadow-[var(--shadow-sm)] ${
         isActive
-          ? "border-[var(--accent)] bg-[var(--accent-soft)]/70"
-          : "border-[var(--border)] bg-[var(--surface)]/90"
+          ? "border-[var(--accent)] bg-[var(--surface)]/96"
+          : "border-[var(--border)] bg-[var(--surface)]/92"
       }`}
       data-active={isActive ? "true" : "false"}
       data-background-id={backgroundId}
       data-testid="background-block"
     >
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">
-            Background shift
-          </p>
-          <p className="mt-2 text-sm font-semibold text-[var(--text)]">{backgroundId}</p>
+      {backgroundPath ? (
+        <div className="relative overflow-hidden rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface-muted)]">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt={`${backgroundId} background preview`}
+            className="h-36 w-full object-cover object-center"
+            data-testid="background-preview-image"
+            src={backgroundPath}
+          />
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--bg) 18%, transparent) 42%, color-mix(in srgb, var(--bg) 92%, transparent) 100%)",
+            }}
+          />
+          <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-3 p-4">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                Background shift
+              </p>
+              <p className="mt-2 text-base font-semibold tracking-[-0.02em] text-[var(--text)]">
+                {backgroundId}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Badge variant="default">Preview ready</Badge>
+              {isActive ? <Badge variant="accent">Active</Badge> : null}
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          {backgroundPath ? <Badge variant="default">Backdrop ready</Badge> : null}
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+              Background shift
+            </p>
+            <p className="mt-2 text-sm font-semibold tracking-[-0.02em] text-[var(--text)]">
+              {backgroundId}
+            </p>
+          </div>
           {isActive ? <Badge variant="accent">Active</Badge> : null}
         </div>
+      )}
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm leading-6 text-[var(--text-muted)]">
+          스크롤이 이 지점을 통과하면 story backdrop이 이 장면의 배경으로 전환됩니다.
+        </p>
+        {!backgroundPath ? <Badge variant="default">No bundled image</Badge> : null}
       </div>
     </article>
   );
@@ -227,7 +317,7 @@ function StoryFloatingTopButton() {
 
   return (
     <Button
-      className="fixed bottom-6 right-6 z-40 h-12 rounded-full px-4"
+      className="fixed bottom-6 right-6 z-40 h-11 rounded-[var(--radius-md)] px-4"
       data-testid="scroll-top-button"
       onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
       variant="accent"
@@ -271,16 +361,18 @@ function StoryBlocks({
                 />
                 <div className="pt-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-muted)]">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
                       Dialogue
                     </p>
                     {block.isRemote ? (
-                      <Badge variant="accent" className="text-[10px] uppercase tracking-[0.18em]">
+                      <Badge variant="accent" className="text-[10px] uppercase tracking-[0.14em]">
                         Wireless link
                       </Badge>
                     ) : null}
                   </div>
-                  <h3 className="text-lg font-semibold text-[var(--text)]">{block.speakerName}</h3>
+                  <h3 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text)]">
+                    {block.speakerName}
+                  </h3>
                 </div>
               </div>
               <p className="max-w-[72ch] whitespace-pre-wrap text-base leading-8 text-[var(--text)]">
@@ -296,7 +388,7 @@ function StoryBlocks({
               key={`narration-${index}`}
               className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)]/95 p-5 shadow-[var(--shadow-sm)]"
             >
-              <p className="max-w-[72ch] whitespace-pre-wrap font-[var(--font-display)] text-lg leading-8 text-[var(--text)]">
+              <p className="max-w-[72ch] whitespace-pre-wrap text-[1.02rem] leading-8 text-[var(--text)]">
                 {block.text}
               </p>
             </article>
@@ -334,10 +426,12 @@ function StoryBlocks({
             data-testid="choice-block"
           >
             <div className="space-y-2">
-              <p className="text-xs uppercase tracking-[0.2em] text-[var(--accent-strong)]">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--accent-strong)]">
                 Doctor choice
               </p>
-              <h3 className="text-2xl font-semibold text-[var(--text)]">Available responses</h3>
+              <h3 className="text-2xl font-semibold tracking-[-0.02em] text-[var(--text)]">
+                Available responses
+              </h3>
             </div>
             <div className="mt-5 grid gap-4">
               {block.options.map((option) => (
@@ -443,7 +537,7 @@ export function ReaderStoryShell({
             <Badge variant="default">{story.storyId}</Badge>
           </div>
           <div className="space-y-2">
-            <h1 className="font-[var(--font-display)] text-4xl leading-tight md:text-5xl">
+            <h1 className="font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.03em] md:text-5xl">
               {story.title}
             </h1>
             <p className="max-w-3xl text-sm leading-7 text-[var(--text-muted)] md:text-base">
@@ -493,7 +587,7 @@ export function ReaderStoryShell({
                   href={getReaderStoryHref(locale, entry.groupId, entry.storyId)}
                 >
                   <span className="block font-semibold">{entry.title}</span>
-                  <span className="mt-1 block text-xs uppercase tracking-[0.16em] text-[var(--text-muted)]">
+                  <span className="mt-1 block text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
                     {entry.storyCode ?? entry.storyId}
                   </span>
                   <span className="mt-1 block text-xs text-[var(--text-muted)]">

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -23,9 +23,11 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - app-level light/dark theme toggle persisted through the preferences feature
 - canonical locale archive routes, group overview routes, and direct story deep links
 - first-pass story body rendering sourced from bundled story detail JSON
-- a rounded floating app bar shared by home, archive, group, and story routes
+- a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button
 - story-only dynamic backdrop transitions driven by bundled background blocks, while non-story pages keep the archive base background
+- in-flow background blocks keep their own bundled image previews even while they drive the fixed story backdrop
+- the UI uses a sans-first type system and a tighter radius scale for more consistent modern chrome
 - a generated-content readiness panel and explicit summary empty state sourced from bundled JSON
 - gh-pages-safe reader routes rendered from exported static files under the `/ark-str/` base path
 - no framework starter copy, remote links, or vendor branding

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -24,6 +24,8 @@ This v1 does not include:
 ## Foundations
 
 - visual tone: editorial archive
+- typography: sans-first, with display and body tokens kept in the same modern family
+- surface language: restrained radii and compact chrome instead of pill-heavy cards
 - implementation base: shadcn-style shared primitives customized for this project
 - theme strategy: light and dark from the start
 - runtime rule: no remote fonts, assets, or scripts

--- a/docs/exec-plans/completed/reader-visual-refresh.md
+++ b/docs/exec-plans/completed/reader-visual-refresh.md
@@ -1,0 +1,40 @@
+# Reader Visual Refresh
+
+## Objective
+
+Refine the reader surface so in-flow background cards show real previews, story backdrops fade between active images, and the shared chrome feels more modern and visually consistent.
+
+## Scope
+
+- add bundled image previews to background marker cards in story flow
+- change story backdrop swaps to a fade transition
+- tighten typography and radius tokens toward a sans-first, less rounded system
+- align floating app bar and shared reader surfaces to the updated tokens
+
+## Constraints
+
+- keep the existing archive background mood on non-story routes
+- keep dynamic media backgrounds limited to story routes
+- keep background blocks in the story flow instead of replacing them with backdrop-only behavior
+- do not introduce remote fonts or assets
+
+## Tasks
+
+- update global design tokens and shared primitives for the sans-first, restrained chrome direction
+- refresh the floating app bar and shared reader surfaces to use the new token scale
+- add background card image previews while preserving marker metadata
+- implement cross-fade story backdrop transitions instead of instant swaps
+- update design-system and frontend docs to describe the refined contract
+
+## Verification
+
+- `npm --prefix ark-str-web-app run verify`
+- `npm run smoke`
+- `npm run verify`
+
+## Decision Log
+
+- background cards keep their inline role and show the same bundled image that powers the story backdrop
+- backdrop transitions use CSS opacity/transform fades rather than a hard image swap
+- typography is unified around a local sans stack instead of the earlier serif/sans split
+- radius scale is reduced globally rather than only flattening the story route

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,20 +1,19 @@
 # Latest Iteration
 
-Latest parent iteration: `#40`
+Latest parent iteration: `#44`
 
 Completed child issue:
 
-- `#41` via merged PR `#42` - refresh the reader information architecture with a floating app bar, group overview routes, generated reading metrics, and story-only dynamic backdrops
+- `#43` via merged PR `#45` - refresh the reader background previews, backdrop transitions, and shared chrome styling
 
 Current closeout outcome:
 
-- home, locale archive, group overview, and story routes now share a rounded floating app bar with locale switching, theme toggle, and in-group story navigation
-- the reader now has a first-class `/reader/[locale]/[groupId]` route that shows story counts, total visible characters, and estimated reading time for each group
-- story pages keep bundled `background` blocks in the reading flow while also driving a fixed blurred backdrop that updates as the reader scrolls
-- story layouts now use left-side group navigation, a central reading column, a full-width summary section below the body, and a floating scroll-to-top action
-- generated content index entries now include visible character counts and reading-time estimates for both stories and groups, with integrity checks enforcing the calculation contract
-- exported-site smoke now covers the home shell, locale archive, group route, story backdrop, story summary section, and reader session recovery under the `/ark-str/` base path
-- `npm run verify` passed on branch `codex-reader-ia-layout-refresh-issue-41` after the group reading-time calculation was corrected to use the generated character total instead of summing per-story minimums
+- story background cards now show bundled image previews while staying in the reading flow as transition markers
+- story-only blurred backdrops now cross-fade between active background images instead of hard switching
+- the shared chrome moved to a sans-first type system with tighter radius and shadow tokens, reducing the earlier overly rounded feel
+- the floating app bar, story cards, navigation surfaces, and summary section now share the same restrained card language across home, archive, group, and story routes
+- exported-site smoke now asserts that a real background preview image is visible on a story with bundled backgrounds
+- `npm run verify` passed on branch `codex-reader-visual-refresh-issue-43`
 
 Remaining product gaps:
 

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -1,7 +1,7 @@
 # Arknights Story Reader
 
 Status: active
-Phase: reader IA and layout refresh
+Phase: reader visual refresh
 
 ## Product Goal
 
@@ -68,9 +68,11 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - locale archives route into dedicated group overview pages before story routes
 - generated group and story metrics for total visible characters and estimated reading time
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
-- story pages keep `background` blocks in the flow as transition markers while the backdrop updates on scroll
+- story pages keep `background` blocks in the flow as transition markers with bundled preview images while the backdrop updates on scroll
+- story-page backdrop transitions fade between active images instead of switching instantly
 - story pages place group story navigation on the left and a floating scroll-to-top action at the lower right
 - Doctor choice normalization no longer renders a nested "Shared response" section; predicates that reference every option are treated as post-choice continuation
 - gh-pages-safe static export under the `/ark-str/` base path
 - isolated `.next-dev` and `.next-export` caches so `npm run verify` does not degrade the next `npm run dev` startup
 - a manual GitHub Actions Pages workflow that rebuilds, verifies, and publishes `ark-str-web-app/out`
+- the visual system uses a sans-first type stack and a more restrained radius scale while keeping the archive background mood

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -72,6 +72,26 @@ function resolveSampleStory() {
   throw new Error("A sample reader story with observedOperators and a bundled portrait is required for smoke tests.");
 }
 
+function resolveBackgroundStory() {
+  const prioritizedStories = [
+    ...generatedIndex.stories.filter(
+      (story: { server: string; bodyAvailable?: boolean }) => story.server === "kr" && story.bodyAvailable,
+    ),
+    ...generatedIndex.stories.filter(
+      (story: { server: string; bodyAvailable?: boolean }) => story.server !== "kr" && story.bodyAvailable,
+    ),
+  ];
+
+  for (const story of prioritizedStories) {
+    const detail = readStoryDetail(story);
+    if (detail?.blocks?.some((block: { type?: string }) => block.type === "background")) {
+      return story;
+    }
+  }
+
+  throw new Error("A sample reader story with a background block is required for smoke tests.");
+}
+
 const sampleStorySelection = resolveSampleStory();
 const sampleStory = sampleStorySelection.story;
 const sampleObservedOperator =
@@ -82,6 +102,7 @@ const sampleObservedAlias =
   sampleObservedOperator?.aliases.find((alias) => alias.trim().length > 0 && alias !== "???") ??
   sampleObservedOperator?.aliases[0] ??
   null;
+const sampleBackgroundStory = resolveBackgroundStory();
 
 function toAppPath(route = "") {
   const normalizedRoute = route.replace(/^\/+/, "");
@@ -216,6 +237,14 @@ test.describe("reader shell smoke", () => {
       await observedSpeakerArticle.scrollIntoViewIfNeeded();
       await expect(observedSpeakerArticle.getByTestId("speaker-portrait-image")).toBeVisible();
     }
+
+    await page.goto(
+      toAppPath(
+        `reader/${sampleBackgroundStory.server}/${sampleBackgroundStory.groupId}/${sampleBackgroundStory.storyId}`,
+      ),
+    );
+    await expect(page.getByTestId("background-block").first()).toBeVisible();
+    await expect(page.getByTestId("background-preview-image").first()).toBeVisible();
 
     await page.goto(toAppPath());
     await expect(page.getByTestId("last-visited-story")).toContainText(sampleStory.title);


### PR DESCRIPTION
## Summary\n- add bundled image previews to in-flow background cards and fade story backdrop transitions\n- tighten the reader visual system around sans-first typography and restrained radii\n- refresh smoke coverage for bundled background previews\n\n## Testing\n- npm run verify\n\nCloses #43\nParent #44