### PR TITLE
Refine story surface backdrop and card layout

### DIFF
--- a/ark-str-web-app/src/app/globals.css
+++ b/ark-str-web-app/src/app/globals.css
@@ -39,6 +39,7 @@
   --shadow-lg: 0 26px 64px rgba(28, 42, 54, 0.16);
   --motion-fast: 160ms;
   --motion-base: 260ms;
+  --motion-slow: 500ms;
 }
 
 html[data-theme="dark"] {
@@ -125,17 +126,5 @@ textarea {
 }
 
 .story-backdrop-media {
-  transition:
-    opacity var(--motion-base) ease,
-    transform calc(var(--motion-base) + 80ms) ease;
-}
-
-.story-backdrop-media[data-state="inactive"] {
-  opacity: 0;
-  transform: scale(1.03);
-}
-
-.story-backdrop-media[data-state="active"] {
-  opacity: 1;
-  transform: scale(1);
+  transition: opacity var(--motion-slow) ease;
 }

--- a/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
@@ -20,6 +20,8 @@ import type {
 } from "@/features/content/types";
 import { useReaderSession } from "@/features/reader/runtime/reader-session-context";
 
+const STORY_BACKDROP_FADE_MS = 500;
+
 function formatMetric(value: number) {
   return new Intl.NumberFormat("ko-KR").format(value);
 }
@@ -33,7 +35,7 @@ function ReaderPortraitSlot({
 }) {
   return (
     <div
-      className="flex h-20 w-16 shrink-0 items-start justify-center overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)]"
+      className="flex h-24 w-20 shrink-0 items-start justify-center overflow-hidden rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)]"
       data-testid="speaker-portrait-slot"
     >
       {portraitPath ? (
@@ -42,9 +44,9 @@ function ReaderPortraitSlot({
           alt={`${speakerName} portrait`}
           className="block h-full w-full object-cover object-top"
           data-testid="speaker-portrait-image"
-          height={80}
+          height={96}
           src={portraitPath}
-          width={64}
+          width={80}
         />
       ) : null}
     </div>
@@ -123,69 +125,84 @@ function collectBackgroundSequenceFromBlocks(blocks: StoryBlock[], accumulator: 
 }
 
 function StoryBackdrop({ backgroundPath }: { backgroundPath: string | null }) {
-  const [committedPath, setCommittedPath] = useState<string | null>(backgroundPath);
-  const [incomingPath, setIncomingPath] = useState<string | null>(null);
+  const [currentPath, setCurrentPath] = useState<string | null>(backgroundPath);
+  const [previousPath, setPreviousPath] = useState<string | null>(null);
+  const [isTransitionArmed, setIsTransitionArmed] = useState(false);
+  const currentPathRef = useRef<string | null>(backgroundPath);
 
   useEffect(() => {
+    currentPathRef.current = currentPath;
+  }, [currentPath]);
+
+  useEffect(() => {
+    const committedPath = currentPathRef.current;
+
     if (backgroundPath === committedPath) {
       return;
     }
 
+    let settleRafId: number | null = null;
     let timeoutId: number | null = null;
     const rafId = window.requestAnimationFrame(() => {
       if (!backgroundPath) {
-        setCommittedPath(null);
-        setIncomingPath(null);
+        setCurrentPath(null);
+        setPreviousPath(null);
+        setIsTransitionArmed(false);
         return;
       }
 
       if (!committedPath) {
-        setCommittedPath(backgroundPath);
-        setIncomingPath(null);
+        setCurrentPath(backgroundPath);
+        setPreviousPath(null);
+        setIsTransitionArmed(false);
         return;
       }
 
-      setIncomingPath(backgroundPath);
+      setPreviousPath(committedPath);
+      setCurrentPath(backgroundPath);
+      setIsTransitionArmed(true);
+
+      settleRafId = window.requestAnimationFrame(() => {
+        setIsTransitionArmed(false);
+      });
       timeoutId = window.setTimeout(() => {
-        setCommittedPath(backgroundPath);
-        setIncomingPath(null);
-      }, 320);
+        setPreviousPath(null);
+      }, STORY_BACKDROP_FADE_MS);
     });
 
     return () => {
       window.cancelAnimationFrame(rafId);
+      if (settleRafId !== null) {
+        window.cancelAnimationFrame(settleRafId);
+      }
       if (timeoutId !== null) {
         window.clearTimeout(timeoutId);
       }
     };
-  }, [backgroundPath, committedPath]);
-
-  const resolvedPath = incomingPath ?? committedPath;
+  }, [backgroundPath]);
 
   return (
     <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden" data-testid="story-backdrop">
-      {resolvedPath ? (
+      {currentPath ? (
         <>
-          {committedPath ? (
+          {previousPath ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               alt=""
               aria-hidden="true"
               className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
-              data-state={incomingPath ? "inactive" : "active"}
-              src={committedPath}
+              style={{ opacity: isTransitionArmed ? 1 : 0 }}
+              src={previousPath}
             />
           ) : null}
-          {incomingPath ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt=""
-              aria-hidden="true"
-              className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
-              data-state="active"
-              src={incomingPath}
-            />
-          ) : null}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt=""
+            aria-hidden="true"
+            className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
+            style={{ opacity: isTransitionArmed ? 0 : 1 }}
+            src={currentPath}
+          />
           <div className="story-backdrop-overlay absolute inset-0" />
           <div className="story-backdrop-highlight absolute inset-0" />
         </>
@@ -245,55 +262,20 @@ function StoryBackgroundMarker({
       data-testid="background-block"
     >
       {backgroundPath ? (
-        <div className="relative overflow-hidden rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface-muted)]">
+        <div className="overflow-hidden rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--surface-muted)] p-3">
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             alt={`${backgroundId} background preview`}
-            className="h-36 w-full object-cover object-center"
+            className="max-h-[22rem] w-full object-contain object-center"
             data-testid="background-preview-image"
             src={backgroundPath}
           />
-          <div
-            className="absolute inset-0"
-            style={{
-              background:
-                "linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--bg) 18%, transparent) 42%, color-mix(in srgb, var(--bg) 92%, transparent) 100%)",
-            }}
-          />
-          <div className="absolute inset-x-0 bottom-0 flex items-end justify-between gap-3 p-4">
-            <div>
-              <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                Background shift
-              </p>
-              <p className="mt-2 text-base font-semibold tracking-[-0.02em] text-[var(--text)]">
-                {backgroundId}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Badge variant="default">Preview ready</Badge>
-              {isActive ? <Badge variant="accent">Active</Badge> : null}
-            </div>
-          </div>
         </div>
       ) : (
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-              Background shift
-            </p>
-            <p className="mt-2 text-sm font-semibold tracking-[-0.02em] text-[var(--text)]">
-              {backgroundId}
-            </p>
-          </div>
-          {isActive ? <Badge variant="accent">Active</Badge> : null}
+        <div className="rounded-[var(--radius-md)] border border-dashed border-[var(--border)] bg-[var(--surface-muted)]/60 px-4 py-5 text-sm text-[var(--text-muted)]">
+          {backgroundId}
         </div>
       )}
-      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-        <p className="text-sm leading-6 text-[var(--text-muted)]">
-          스크롤이 이 지점을 통과하면 story backdrop이 이 장면의 배경으로 전환됩니다.
-        </p>
-        {!backgroundPath ? <Badge variant="default">No bundled image</Badge> : null}
-      </div>
     </article>
   );
 }
@@ -348,34 +330,31 @@ function StoryBlocks({
           return (
             <article
               key={`dialogue-${index}`}
-              className={`grid gap-4 rounded-[var(--radius-lg)] border bg-[var(--surface)]/94 p-4 shadow-[var(--shadow-sm)] md:grid-cols-[72px_minmax(0,1fr)] ${
+              className={`flex flex-col gap-4 rounded-[var(--radius-lg)] border bg-[var(--surface)]/94 p-4 shadow-[var(--shadow-sm)] ${
                 block.isRemote
                   ? "border-[var(--accent)] border-dashed"
                   : "border-[var(--border)]"
               }`}
             >
-              <div className="flex items-start gap-3">
+              <div className="flex items-start gap-4">
                 <ReaderPortraitSlot
                   portraitPath={block.speakerId ? (portraitPaths[block.speakerId] ?? null) : null}
                   speakerName={block.speakerName}
                 />
-                <div className="pt-1">
+                <div className="min-w-0 flex-1 pt-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                      Dialogue
-                    </p>
+                    <h3 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text)]">
+                      {block.speakerName}
+                    </h3>
                     {block.isRemote ? (
                       <Badge variant="accent" className="text-[10px] uppercase tracking-[0.14em]">
                         Wireless link
                       </Badge>
                     ) : null}
                   </div>
-                  <h3 className="text-lg font-semibold tracking-[-0.02em] text-[var(--text)]">
-                    {block.speakerName}
-                  </h3>
                 </div>
               </div>
-              <p className="max-w-[72ch] whitespace-pre-wrap text-base leading-8 text-[var(--text)]">
+              <p className="whitespace-pre-wrap text-[1.02rem] leading-8 text-[var(--text)]">
                 {block.text}
               </p>
             </article>
@@ -388,7 +367,7 @@ function StoryBlocks({
               key={`narration-${index}`}
               className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)]/95 p-5 shadow-[var(--shadow-sm)]"
             >
-              <p className="max-w-[72ch] whitespace-pre-wrap text-[1.02rem] leading-8 text-[var(--text)]">
+              <p className="whitespace-pre-wrap text-[1.02rem] leading-8 text-[var(--text)]">
                 {block.text}
               </p>
             </article>
@@ -540,7 +519,7 @@ export function ReaderStoryShell({
             <h1 className="font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.03em] md:text-5xl">
               {story.title}
             </h1>
-            <p className="max-w-3xl text-sm leading-7 text-[var(--text-muted)] md:text-base">
+            <p className="max-w-5xl text-sm leading-7 text-[var(--text-muted)] md:text-base">
               {story.sourcePath}
             </p>
           </div>
@@ -562,45 +541,45 @@ export function ReaderStoryShell({
       <CharacterObservationTracker detail={detail} locale={locale} />
       <StoryBackdrop backgroundPath={activeBackgroundPath} />
 
-      <section className="relative z-10 grid gap-6 xl:grid-cols-[280px_minmax(0,1fr)]">
-        <aside className="grid gap-4 self-start xl:sticky xl:top-28">
-          <Card className="bg-[var(--surface)]/90 backdrop-blur-sm">
-            <CardHeader>
-              <Badge variant="default" className="w-fit">
-                Group
-              </Badge>
-              <CardTitle>{group.title}</CardTitle>
-              <CardDescription>
-                {group.storyCount} stories · {formatMetric(group.totalVisibleCharacterCount)} chars · 약{" "}
-                {formatMetric(group.estimatedMinutes)}분
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-2">
-              {siblingStories.map((entry) => (
-                <Link
-                  key={entry.storyId}
-                  className={`rounded-[var(--radius-md)] border px-3 py-3 text-sm transition duration-[var(--motion-fast)] ease-out ${
-                    entry.storyId === story.storyId
-                      ? "border-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent-strong)]"
-                      : "border-[var(--border)] bg-[var(--panel)]/90 text-[var(--text)] hover:border-[var(--accent)] hover:bg-[var(--surface-muted)]"
-                  }`}
-                  href={getReaderStoryHref(locale, entry.groupId, entry.storyId)}
-                >
-                  <span className="block font-semibold">{entry.title}</span>
-                  <span className="mt-1 block text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
-                    {entry.storyCode ?? entry.storyId}
-                  </span>
-                  <span className="mt-1 block text-xs text-[var(--text-muted)]">
-                    {formatMetric(entry.visibleCharacterCount)} chars · 약{" "}
-                    {formatMetric(entry.estimatedMinutes)}분
-                  </span>
-                </Link>
-              ))}
-            </CardContent>
-          </Card>
-        </aside>
+      <section className="relative z-10 grid gap-6">
+        <div className="grid gap-6 xl:grid-cols-[260px_minmax(0,1fr)]">
+          <aside className="grid gap-4 self-start xl:sticky xl:top-28">
+            <Card className="bg-[var(--surface)]/90 backdrop-blur-sm">
+              <CardHeader>
+                <Badge variant="default" className="w-fit">
+                  Group
+                </Badge>
+                <CardTitle>{group.title}</CardTitle>
+                <CardDescription>
+                  {group.storyCount} stories · {formatMetric(group.totalVisibleCharacterCount)} chars · 약{" "}
+                  {formatMetric(group.estimatedMinutes)}분
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="grid gap-2">
+                {siblingStories.map((entry) => (
+                  <Link
+                    key={entry.storyId}
+                    className={`rounded-[var(--radius-md)] border px-3 py-3 text-sm transition duration-[var(--motion-fast)] ease-out ${
+                      entry.storyId === story.storyId
+                        ? "border-[var(--accent)] bg-[var(--accent-soft)] text-[var(--accent-strong)]"
+                        : "border-[var(--border)] bg-[var(--panel)]/90 text-[var(--text)] hover:border-[var(--accent)] hover:bg-[var(--surface-muted)]"
+                    }`}
+                    href={getReaderStoryHref(locale, entry.groupId, entry.storyId)}
+                  >
+                    <span className="block font-semibold">{entry.title}</span>
+                    <span className="mt-1 block text-[10px] uppercase tracking-[0.14em] text-[var(--text-muted)]">
+                      {entry.storyCode ?? entry.storyId}
+                    </span>
+                    <span className="mt-1 block text-xs text-[var(--text-muted)]">
+                      {formatMetric(entry.visibleCharacterCount)} chars · 약{" "}
+                      {formatMetric(entry.estimatedMinutes)}분
+                    </span>
+                  </Link>
+                ))}
+              </CardContent>
+            </Card>
+          </aside>
 
-        <div className="grid gap-6">
           <section className="grid gap-4">
             {isBodyAvailable ? (
               <StoryBodyRenderer
@@ -619,37 +598,37 @@ export function ReaderStoryShell({
               </Card>
             )}
           </section>
-
-          <section className="xl:col-span-2" data-testid="story-summary-section">
-            <Card className="bg-[var(--surface)]/92 backdrop-blur-sm">
-              <CardHeader>
-                <Badge variant="default" className="w-fit">
-                  Summary
-                </Badge>
-                <CardTitle>Story summary</CardTitle>
-                <CardDescription>
-                  summary는 스토리 본문 아래 전체폭 영역에서 제공합니다.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {summaryAvailable ? (
-                  <p className="text-sm leading-7 text-[var(--text)]">
-                    summary contract is marked available, but summary rendering is not implemented in
-                    this issue.
-                  </p>
-                ) : (
-                  <div
-                    className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)] p-4 text-sm leading-7 text-[var(--text-muted)]"
-                    data-testid="summary-empty-state"
-                  >
-                    이 스토리의 summary는 아직 생성되지 않았습니다. 후속 파이프라인 이슈에서
-                    summary와 character unlock fact가 추가됩니다.
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </section>
         </div>
+
+        <section data-testid="story-summary-section">
+          <Card className="bg-[var(--surface)]/92 backdrop-blur-sm">
+            <CardHeader>
+              <Badge variant="default" className="w-fit">
+                Summary
+              </Badge>
+              <CardTitle>Story summary</CardTitle>
+              <CardDescription>
+                summary는 스토리 본문 아래 전체폭 영역에서 제공합니다.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {summaryAvailable ? (
+                <p className="text-sm leading-7 text-[var(--text)]">
+                  summary contract is marked available, but summary rendering is not implemented in this
+                  issue.
+                </p>
+              ) : (
+                <div
+                  className="rounded-[var(--radius-lg)] border border-[var(--border)] bg-[var(--panel)] p-4 text-sm leading-7 text-[var(--text-muted)]"
+                  data-testid="summary-empty-state"
+                >
+                  이 스토리의 summary는 아직 생성되지 않았습니다. 후속 파이프라인 이슈에서 summary와
+                  character unlock fact가 추가됩니다.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
       </section>
 
       <StoryFloatingTopButton />

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -26,8 +26,10 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button
 - story-only dynamic backdrop transitions driven by bundled background blocks, while non-story pages keep the archive base background
-- in-flow background blocks keep their own bundled image previews even while they drive the fixed story backdrop
+- in-flow background blocks keep their own bundled image previews without cropping and still drive the fixed story backdrop
+- story backdrop swaps on story pages use a slower 0.5 second cross-fade instead of a hard cut
 - the UI uses a sans-first type system and a tighter radius scale for more consistent modern chrome
+- dialogue cards prioritize a vertical reading layout with portrait and speaker meta in the header and the body text spanning the full card width
 - a generated-content readiness panel and explicit summary empty state sourced from bundled JSON
 - gh-pages-safe reader routes rendered from exported static files under the `/ark-str/` base path
 - no framework starter copy, remote links, or vendor branding

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -26,6 +26,7 @@ This v1 does not include:
 - visual tone: editorial archive
 - typography: sans-first, with display and body tokens kept in the same modern family
 - surface language: restrained radii and compact chrome instead of pill-heavy cards
+- story surfaces: dynamic story backdrops fade behind the content while in-flow background cards keep uncropped image previews and dialogue cards prioritize body-first reading layouts
 - implementation base: shadcn-style shared primitives customized for this project
 - theme strategy: light and dark from the start
 - runtime rule: no remote fonts, assets, or scripts

--- a/docs/exec-plans/completed/story-surface-refinement.md
+++ b/docs/exec-plans/completed/story-surface-refinement.md
@@ -1,0 +1,39 @@
+# Story Surface Refinement
+
+## Objective
+
+Refine the story reading surface so backdrop transitions feel gradual, background marker cards show full preview images, and dialogue cards read more naturally across the wider story column.
+
+## Scope
+
+- change story-page backdrop swaps to a 0.5 second cross-fade
+- widen the story reading surface so it tracks more closely with the floating app bar width
+- keep background blocks in the story flow, but remove the extra marker chrome and show uncropped preview images
+- rework dialogue cards into a portrait-plus-header layout with full-width body text
+
+## Constraints
+
+- keep story-only dynamic backdrops limited to story pages
+- keep non-story pages on the archive base background
+- do not remove background blocks from the story flow
+- keep runtime assets bundled only and finish with `npm run verify`
+
+## Tasks
+
+- replace the current backdrop swap timing with an explicit 500ms fade
+- move summary back to a full-width section beneath the story/content row
+- remove `Background shift`, `Preview ready`, and `Active` labels from background markers
+- render bundled background previews with `object-contain`
+- simplify dialogue cards so the portrait and speaker metadata sit in the header and the text uses the full card width
+- update reader-facing docs and the iteration summary to match the new contract
+
+## Verification
+
+- `npm run verify`
+
+## Decision Log
+
+- backdrop transitions now use a slower 500ms cross-fade instead of the earlier quick swap
+- background markers keep a subtle active border but no longer render explanatory status text
+- preview images preserve their full aspect ratio even if that introduces letterboxing within the card
+- the story reading surface now uses a separate full-width summary row under the main content grid

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,19 +1,18 @@
 # Latest Iteration
 
-Latest parent iteration: `#44`
+Latest parent iteration: `#47`
 
 Completed child issue:
 
-- `#43` via merged PR `#45` - refresh the reader background previews, backdrop transitions, and shared chrome styling
+- `#46` via merged PR `#48` - refine the story backdrop fade, story-width balance, and reader card surfaces
 
 Current closeout outcome:
 
-- story background cards now show bundled image previews while staying in the reading flow as transition markers
-- story-only blurred backdrops now cross-fade between active background images instead of hard switching
-- the shared chrome moved to a sans-first type system with tighter radius and shadow tokens, reducing the earlier overly rounded feel
-- the floating app bar, story cards, navigation surfaces, and summary section now share the same restrained card language across home, archive, group, and story routes
-- exported-site smoke now asserts that a real background preview image is visible on a story with bundled backgrounds
-- `npm run verify` passed on branch `codex-reader-visual-refresh-issue-43`
+- story-only background swaps now use a slower 0.5 second cross-fade instead of the earlier abrupt transition feel
+- the story layout now keeps the left navigation row but gives the main body and summary a broader reading surface that lines up more closely with the floating app bar width
+- in-flow background markers still drive the backdrop, but bundled preview images now preserve their full aspect ratio and the extra status chrome has been removed
+- dialogue cards now use a portrait-plus-header layout with full-width body text, while remote cutins still carry the `Wireless link` indicator in the header
+- `npm run verify` passed on branch `codex-story-surface-refinement-issue-46`
 
 Remaining product gaps:
 

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -68,9 +68,10 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - locale archives route into dedicated group overview pages before story routes
 - generated group and story metrics for total visible characters and estimated reading time
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
-- story pages keep `background` blocks in the flow as transition markers with bundled preview images while the backdrop updates on scroll
-- story-page backdrop transitions fade between active images instead of switching instantly
+- story pages keep `background` blocks in the flow as transition markers with bundled preview images shown uncropped while the backdrop updates on scroll
+- story-page backdrop transitions use a slower 0.5 second fade between active images instead of switching instantly
 - story pages place group story navigation on the left and a floating scroll-to-top action at the lower right
+- dialogue cards use a portrait-plus-header layout that gives the spoken text the full card width instead of a narrow side-by-side split
 - Doctor choice normalization no longer renders a nested "Shared response" section; predicates that reference every option are treated as post-choice continuation
 - gh-pages-safe static export under the `/ark-str/` base path
 - isolated `.next-dev` and `.next-export` caches so `npm run verify` does not degrade the next `npm run dev` startup


### PR DESCRIPTION
## Summary
- slow story backdrop swaps to a 0.5s fade and broaden the reader layout under the floating app bar
- simplify in-flow background markers to uncropped image previews and remove the extra status chrome
- reshape dialogue cards into a portrait-plus-header layout with full-width body text

## Verification
- npm run verify

Closes #46
