### PR TITLE
fix: simplify reader navigation and backdrop behavior

### DIFF
--- a/ark-str-web-app/src/app/globals.css
+++ b/ark-str-web-app/src/app/globals.css
@@ -74,12 +74,12 @@ html[data-theme="dark"] {
 }
 
 html {
-  background:
-    radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 18%, transparent), transparent 38%),
-    linear-gradient(180deg, color-mix(in srgb, var(--bg) 94%, white) 0%, var(--bg) 100%);
+  background: var(--bg);
 }
 
 body {
+  position: relative;
+  isolation: isolate;
   min-height: 100vh;
   background: transparent;
   color: var(--text);
@@ -88,6 +88,22 @@ body {
   transition:
     background-color var(--motion-base) ease,
     color var(--motion-base) ease;
+}
+
+body::before {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  content: "";
+  background:
+    radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 18%, transparent), transparent 38%),
+    linear-gradient(180deg, color-mix(in srgb, var(--bg) 94%, white) 0%, var(--bg) 100%);
+}
+
+body > * {
+  position: relative;
+  z-index: 0;
 }
 
 a {
@@ -123,8 +139,4 @@ textarea {
 
 .story-backdrop-highlight {
   background: radial-gradient(circle at top, rgba(255, 255, 255, 0.14), transparent 34%);
-}
-
-.story-backdrop-media {
-  transition: opacity var(--motion-slow) ease;
 }

--- a/ark-str-web-app/src/app/reader/[locale]/[groupId]/[storyId]/page.tsx
+++ b/ark-str-web-app/src/app/reader/[locale]/[groupId]/[storyId]/page.tsx
@@ -11,6 +11,7 @@ import {
   findSummaryEntry,
   getGroupStories,
   getReaderGroupHref,
+  getReaderLocaleHref,
   getReaderStoryStaticParams,
   getReaderStoryHref,
   readStoryBackgroundPaths,
@@ -65,7 +66,7 @@ export default async function ReaderStoryPage({
           label: READER_LOCALE_LABELS[targetLocale].label,
           href: buildLocaleSwitchHref(index, targetLocale, groupId, storyId),
         })),
-        storyRootHref: getReaderGroupHref(locale, groupId),
+        storyRootHref: getReaderLocaleHref(locale),
         groupCrumb: {
           label: group.title,
           href: getReaderGroupHref(locale, groupId),

--- a/ark-str-web-app/src/app/reader/[locale]/[groupId]/page.tsx
+++ b/ark-str-web-app/src/app/reader/[locale]/[groupId]/page.tsx
@@ -8,8 +8,8 @@ import {
   buildLocaleSwitchHref,
   findGroupEntry,
   getGroupStories,
-  getReaderGroupHref,
   getReaderGroupStaticParams,
+  getReaderLocaleHref,
   readContentIndex,
 } from "@/features/content/service/read-content-index";
 import { ReaderGroupOverview } from "@/features/reader/ui/reader-group-overview";
@@ -48,7 +48,7 @@ export default async function ReaderGroupPage({
           label: READER_LOCALE_LABELS[targetLocale].label,
           href: buildLocaleSwitchHref(index, targetLocale, groupId),
         })),
-        storyRootHref: getReaderGroupHref(locale, groupId),
+        storyRootHref: getReaderLocaleHref(locale),
         groupCrumb: {
           label: group.title,
           href: null,

--- a/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
@@ -20,8 +20,6 @@ import type {
 } from "@/features/content/types";
 import { useReaderSession } from "@/features/reader/runtime/reader-session-context";
 
-const STORY_BACKDROP_FADE_MS = 500;
-
 function formatMetric(value: number) {
   return new Intl.NumberFormat("ko-KR").format(value);
 }
@@ -107,101 +105,37 @@ function CharacterObservationTracker({
   return null;
 }
 
-function collectBackgroundSequenceFromBlocks(blocks: StoryBlock[], accumulator: string[] = []) {
+function findFirstBackgroundId(blocks: StoryBlock[]): string | null {
   for (const block of blocks) {
     if (block.type === "background") {
-      accumulator.push(block.backgroundId);
-      continue;
+      return block.backgroundId;
     }
 
     if (block.type === "choice") {
       for (const option of block.options) {
-        collectBackgroundSequenceFromBlocks(option.blocks, accumulator);
+        const optionBackgroundId = findFirstBackgroundId(option.blocks);
+        if (optionBackgroundId) {
+          return optionBackgroundId;
+        }
       }
     }
   }
 
-  return accumulator;
+  return null;
 }
 
 function StoryBackdrop({ backgroundPath }: { backgroundPath: string | null }) {
-  const [currentPath, setCurrentPath] = useState<string | null>(backgroundPath);
-  const [previousPath, setPreviousPath] = useState<string | null>(null);
-  const [isTransitionArmed, setIsTransitionArmed] = useState(false);
-  const currentPathRef = useRef<string | null>(backgroundPath);
-
-  useEffect(() => {
-    currentPathRef.current = currentPath;
-  }, [currentPath]);
-
-  useEffect(() => {
-    const committedPath = currentPathRef.current;
-
-    if (backgroundPath === committedPath) {
-      return;
-    }
-
-    let settleRafId: number | null = null;
-    let timeoutId: number | null = null;
-    const rafId = window.requestAnimationFrame(() => {
-      if (!backgroundPath) {
-        setCurrentPath(null);
-        setPreviousPath(null);
-        setIsTransitionArmed(false);
-        return;
-      }
-
-      if (!committedPath) {
-        setCurrentPath(backgroundPath);
-        setPreviousPath(null);
-        setIsTransitionArmed(false);
-        return;
-      }
-
-      setPreviousPath(committedPath);
-      setCurrentPath(backgroundPath);
-      setIsTransitionArmed(true);
-
-      settleRafId = window.requestAnimationFrame(() => {
-        setIsTransitionArmed(false);
-      });
-      timeoutId = window.setTimeout(() => {
-        setPreviousPath(null);
-      }, STORY_BACKDROP_FADE_MS);
-    });
-
-    return () => {
-      window.cancelAnimationFrame(rafId);
-      if (settleRafId !== null) {
-        window.cancelAnimationFrame(settleRafId);
-      }
-      if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
-      }
-    };
-  }, [backgroundPath]);
-
   return (
     <div className="pointer-events-none fixed inset-0 z-0 overflow-hidden" data-testid="story-backdrop">
-      {currentPath ? (
+      {backgroundPath ? (
         <>
-          {previousPath ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt=""
-              aria-hidden="true"
-              className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
-              style={{ opacity: isTransitionArmed ? 1 : 0 }}
-              src={previousPath}
-            />
-          ) : null}
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             alt=""
             aria-hidden="true"
-            className="story-backdrop-media absolute inset-0 h-full w-full object-cover object-center blur-xl"
-            style={{ opacity: isTransitionArmed ? 0 : 1 }}
-            src={currentPath}
+            className="absolute inset-0 h-full w-full object-cover object-center blur-xl"
+            data-testid="story-backdrop-image"
+            src={backgroundPath}
           />
           <div className="story-backdrop-overlay absolute inset-0" />
           <div className="story-backdrop-highlight absolute inset-0" />
@@ -488,21 +422,23 @@ export function ReaderStoryShell({
   summaryAvailable: boolean;
 }) {
   const isBodyAvailable = story.bodyAvailable && detail;
-  const backgroundSequence = useMemo(
-    () => (detail ? collectBackgroundSequenceFromBlocks(detail.blocks) : []),
-    [detail],
-  );
-  const [selectedBackgroundId, setSelectedBackgroundId] = useState<string | null>(null);
-  const activeBackgroundId = useMemo(() => {
-    if (selectedBackgroundId && backgroundSequence.includes(selectedBackgroundId)) {
-      return selectedBackgroundId;
-    }
+  const initialBackgroundId = useMemo(() => (detail ? findFirstBackgroundId(detail.blocks) : null), [detail]);
+  const [activeBackground, setActiveBackground] = useState<{
+    storyId: string;
+    backgroundId: string | null;
+  }>({
+    storyId: story.storyId,
+    backgroundId: initialBackgroundId,
+  });
+  const activeBackgroundId =
+    activeBackground.storyId === story.storyId ? activeBackground.backgroundId : initialBackgroundId;
 
-    return backgroundSequence[0] ?? null;
-  }, [backgroundSequence, selectedBackgroundId]);
   const handleBackgroundVisible = useCallback((backgroundId: string) => {
-    setSelectedBackgroundId(backgroundId);
-  }, []);
+    setActiveBackground({
+      storyId: story.storyId,
+      backgroundId,
+    });
+  }, [story.storyId]);
   const activeBackgroundPath = activeBackgroundId ? (backgroundPaths[activeBackgroundId] ?? null) : null;
 
   return (

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -25,9 +25,9 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - first-pass story body rendering sourced from bundled story detail JSON
 - a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button
-- story-only dynamic backdrop transitions driven by bundled background blocks, while non-story pages keep the archive base background
+- story-only dynamic backdrops driven directly by intersecting bundled background blocks, while non-story pages keep the archive base background
 - in-flow background blocks keep their own bundled image previews without cropping and still drive the fixed story backdrop
-- story backdrop swaps on story pages use a slower 0.5 second cross-fade instead of a hard cut
+- story backdrop swaps on story pages happen immediately without cross-fade state
 - the UI uses a sans-first type system and a tighter radius scale for more consistent modern chrome
 - dialogue cards prioritize a vertical reading layout with portrait and speaker meta in the header and the body text spanning the full card width
 - a generated-content readiness panel and explicit summary empty state sourced from bundled JSON

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -26,7 +26,7 @@ This v1 does not include:
 - visual tone: editorial archive
 - typography: sans-first, with display and body tokens kept in the same modern family
 - surface language: restrained radii and compact chrome instead of pill-heavy cards
-- story surfaces: dynamic story backdrops fade behind the content while in-flow background cards keep uncropped image previews and dialogue cards prioritize body-first reading layouts
+- story surfaces: dynamic story backdrops switch behind the content from intersecting background blocks while in-flow background cards keep uncropped image previews and dialogue cards prioritize body-first reading layouts
 - implementation base: shadcn-style shared primitives customized for this project
 - theme strategy: light and dark from the start
 - runtime rule: no remote fonts, assets, or scripts

--- a/docs/exec-plans/active/reader-background-nav-cleanup.md
+++ b/docs/exec-plans/active/reader-background-nav-cleanup.md
@@ -1,0 +1,25 @@
+# Reader background and navigation cleanup
+
+## Goal
+
+Fix story-reader chrome navigation and simplify story background behavior for issue #62 under parent #61.
+
+## Issue DAG
+
+- #61 parent iteration: Simplify reader navigation and story background behavior
+- #62 child issue: Fix reader story chrome and static backdrop behavior
+- Dependencies: none
+
+## Scope
+
+- Make the app bar Story link always target the locale archive.
+- Keep the group crumb targeting the current group overview.
+- Move the base gradient to a fixed viewport layer so only foreground content scrolls.
+- Remove story backdrop cross-fade state and CSS.
+- Drive story backdrop selection directly from visible background blocks via IntersectionObserver.
+- Update stale frontend/product/design docs and smoke coverage.
+
+## Validation
+
+- `npm run app:verify`
+- `npm run verify`

--- a/docs/exec-plans/completed/reader-background-nav-cleanup.md
+++ b/docs/exec-plans/completed/reader-background-nav-cleanup.md
@@ -8,6 +8,7 @@ Fix story-reader chrome navigation and simplify story background behavior for is
 
 - #61 parent iteration: Simplify reader navigation and story background behavior
 - #62 child issue: Fix reader story chrome and static backdrop behavior
+- PR: #63
 - Dependencies: none
 
 ## Scope
@@ -22,4 +23,5 @@ Fix story-reader chrome navigation and simplify story background behavior for is
 ## Validation
 
 - `npm run app:verify`
+- `npm run smoke`
 - `npm run verify`

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,18 +1,19 @@
 # Latest Iteration
 
-Latest parent iteration: `#58`
+Latest parent iteration: `#61`
 
 Completed child issue:
 
-- `#59` via PR `#60` - treat negative-focus story frames as visual-only so unrelated dialogue does not inherit an inactive portrait
+- `#62` via PR `#63` - simplify reader story navigation and fixed background behavior
 
 Current closeout outcome:
 
-- `priority < 0` character/charslot frames now remain visual state but are excluded from dialogue speaker selection
-- speaker-name fallback is skipped while any visual frame is still active, preventing stale bindings from adding unrelated portraits
-- `level_act12side_01_beg` now leaves `경박한 관광객` without Chen's `speakerId`, while the following Chen line still resolves to `char_010_chen`
-- generated story detail artifacts were rebuilt with `content:build-index`
-- `npm run verify` passed on branch `codex-negative-focus-speaker-issue-59`
+- story-page app bar `스토리` links now target the locale archive instead of the current group overview
+- group crumbs still target the current group overview from story routes
+- the archive gradient is rendered as a fixed viewport layer so foreground content scrolls independently
+- story backdrop cross-fade state was removed; active backdrop images switch immediately from intersecting background blocks
+- smoke coverage now verifies story navigation, fixed base background, and immediate backdrop source changes
+- `npm run verify` passed on branch `codex-reader-background-nav-issue-62`
 
 Remaining product gaps:
 

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -68,8 +68,8 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - locale archives route into dedicated group overview pages before story routes
 - generated group and story metrics for total visible characters and estimated reading time
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
-- story pages keep `background` blocks in the flow as transition markers with bundled preview images shown uncropped while the backdrop updates on scroll
-- story-page backdrop transitions use a slower 0.5 second fade between active images instead of switching instantly
+- story pages keep `background` blocks in the flow as scroll markers with bundled preview images shown uncropped while the backdrop updates from IntersectionObserver visibility
+- story-page backdrop swaps are immediate; cross-fade state is intentionally omitted to keep the reader surface predictable
 - story pages place group story navigation on the left and a floating scroll-to-top action at the lower right
 - dialogue cards use a portrait-plus-header layout that gives the spoken text the full card width instead of a narrow side-by-side split
 - Doctor choice normalization no longer renders a nested "Shared response" section; predicates that reference every option are treated as post-choice continuation

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -14,6 +14,12 @@ const generatedIndex = JSON.parse(
     "utf8",
   ),
 );
+const generatedBackgrounds = JSON.parse(
+  fs.readFileSync(
+    path.join(process.cwd(), "ark-str-web-app", "src", "generated", "content", "backgrounds.json"),
+    "utf8",
+  ),
+);
 
 function readStoryDetail(story: { bodyPath?: string | null }) {
   if (!story.bodyPath) {
@@ -32,7 +38,14 @@ function readStoryDetail(story: { bodyPath?: string | null }) {
       ),
       "utf8",
     ),
-  ) as { observedOperators?: Array<{ speakerId: string; aliases: string[] }> };
+  ) as {
+    observedOperators?: Array<{ speakerId: string; aliases: string[] }>;
+    blocks?: Array<{
+      type?: string;
+      backgroundId?: string;
+      options?: Array<{ blocks?: unknown[] }>;
+    }>;
+  };
 }
 
 function hasBundledPortrait(speakerId: string) {
@@ -47,6 +60,42 @@ function hasBundledPortrait(speakerId: string) {
       `${speakerId}.png`,
     ),
   );
+}
+
+function hasBundledBackground(backgroundId: string) {
+  return (
+    typeof generatedBackgrounds[backgroundId] === "string" &&
+    fs.existsSync(
+      path.join(
+        process.cwd(),
+        "ark-str-web-app",
+        "public",
+        generatedBackgrounds[backgroundId].replace(/^\/+/, ""),
+      ),
+    )
+  );
+}
+
+function collectBackgroundIds(blocks: Array<{
+  type?: string;
+  backgroundId?: string;
+  options?: Array<{ blocks?: unknown[] }>;
+}> = []) {
+  const ids: string[] = [];
+
+  for (const block of blocks) {
+    if (block.type === "background" && typeof block.backgroundId === "string") {
+      ids.push(block.backgroundId);
+    }
+
+    if (block.type === "choice") {
+      for (const option of block.options ?? []) {
+        ids.push(...collectBackgroundIds(option.blocks as Parameters<typeof collectBackgroundIds>[0]));
+      }
+    }
+  }
+
+  return ids;
 }
 
 function resolveSampleStory() {
@@ -84,16 +133,31 @@ function resolveBackgroundStory() {
 
   for (const story of prioritizedStories) {
     const detail = readStoryDetail(story);
-    if (detail?.blocks?.some((block: { type?: string }) => block.type === "background")) {
-      return story;
+    const backgroundIds = [
+      ...new Set(collectBackgroundIds(detail?.blocks).filter((backgroundId) => hasBundledBackground(backgroundId))),
+    ];
+    if (backgroundIds.length >= 2) {
+      return {
+        story,
+        backgroundIds,
+      };
     }
   }
 
-  throw new Error("A sample reader story with a background block is required for smoke tests.");
+  throw new Error("A sample reader story with multiple bundled background blocks is required for smoke tests.");
 }
 
 const sampleStorySelection = resolveSampleStory();
 const sampleStory = sampleStorySelection.story;
+const sampleStoryGroup = generatedIndex.groups.find(
+  (group: { server: string; groupId: string }) =>
+    group.server === sampleStory.server && group.groupId === sampleStory.groupId,
+);
+
+if (!sampleStoryGroup) {
+  throw new Error("A sample reader story must have a matching group entry.");
+}
+
 const sampleObservedOperator =
   sampleStorySelection.detail.observedOperators?.find((observedOperator) =>
     hasBundledPortrait(observedOperator.speakerId),
@@ -103,6 +167,8 @@ const sampleObservedAlias =
   sampleObservedOperator?.aliases[0] ??
   null;
 const sampleBackgroundStory = resolveBackgroundStory();
+const sampleBackgroundIds = sampleBackgroundStory.backgroundIds;
+const sampleBackgroundStoryEntry = sampleBackgroundStory.story;
 
 function toAppPath(route = "") {
   const normalizedRoute = route.replace(/^\/+/, "");
@@ -185,6 +251,27 @@ test.describe("reader shell smoke", () => {
     await expect(page.getByTestId("story-body")).toBeVisible();
     await expect(page.getByTestId("story-summary-section")).toBeVisible();
 
+    const appBar = page.getByTestId("floating-app-bar");
+    await expect(appBar.getByRole("link", { name: "스토리" })).toHaveAttribute(
+      "href",
+      `/ark-str/reader/${sampleStory.server}/`,
+    );
+
+    await appBar.getByRole("link", { name: "스토리" }).click();
+    await expect(page).toHaveURL(new RegExp(`/ark-str/reader/${sampleStory.server}/$`));
+
+    await page.goto(
+      toAppPath(`reader/${sampleStory.server}/${sampleStory.groupId}/${sampleStory.storyId}`),
+    );
+    await appBar.getByRole("link", { name: sampleStoryGroup.title }).click();
+    await expect(page).toHaveURL(
+      new RegExp(`/ark-str/reader/${sampleStory.server}/${sampleStory.groupId}/$`),
+    );
+
+    await page.goto(
+      toAppPath(`reader/${sampleStory.server}/${sampleStory.groupId}/${sampleStory.storyId}`),
+    );
+
     await page.waitForFunction(
       ([key, locale, speakerId]) => {
         const stored = window.localStorage.getItem(key);
@@ -240,11 +327,27 @@ test.describe("reader shell smoke", () => {
 
     await page.goto(
       toAppPath(
-        `reader/${sampleBackgroundStory.server}/${sampleBackgroundStory.groupId}/${sampleBackgroundStory.storyId}`,
+        `reader/${sampleBackgroundStoryEntry.server}/${sampleBackgroundStoryEntry.groupId}/${sampleBackgroundStoryEntry.storyId}`,
       ),
     );
+    await expect
+      .poll(() => page.evaluate(() => window.getComputedStyle(document.body, "::before").position))
+      .toBe("fixed");
     await expect(page.getByTestId("background-block").first()).toBeVisible();
     await expect(page.getByTestId("background-preview-image").first()).toBeVisible();
+    await expect(page.getByTestId("story-backdrop-image")).toHaveAttribute(
+      "src",
+      `${appBasePath}${generatedBackgrounds[sampleBackgroundIds[0]]}`,
+    );
+
+    const secondBackgroundBlock = page
+      .locator(`[data-testid="background-block"][data-background-id="${sampleBackgroundIds[1]}"]`)
+      .first();
+    await secondBackgroundBlock.evaluate((node) => node.scrollIntoView({ block: "center" }));
+    await expect(page.getByTestId("story-backdrop-image")).toHaveAttribute(
+      "src",
+      `${appBasePath}${generatedBackgrounds[sampleBackgroundIds[1]]}`,
+    );
 
     await page.goto(toAppPath());
     await expect(page.getByTestId("last-visited-story")).toContainText(sampleStory.title);


### PR DESCRIPTION
## Summary
- Fix the story-page app bar Story link so it returns to the locale archive instead of the current group page.
- Move the base gradient into a fixed viewport layer so only foreground content scrolls.
- Remove story backdrop cross-fade state and drive active backdrop selection directly from intersecting background blocks.
- Update frontend/product/design docs and smoke coverage for the behavior.

## Validation
- `npm run app:verify`
- `npm run smoke`
- `npm run verify`

Closes #62

Parent: #61