### PR TITLE
[codex] Polish reader archive disclosure layout

### DIFF
--- a/ark-str-web-app/src/components/ui/disclosure-card.tsx
+++ b/ark-str-web-app/src/components/ui/disclosure-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import * as React from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+type DisclosureCardProps = {
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+  dataStorylineId: string;
+  summary: React.ReactNode;
+  testId: string;
+};
+
+export function DisclosureCard({
+  children,
+  className,
+  contentClassName,
+  dataStorylineId,
+  summary,
+  testId,
+}: DisclosureCardProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const panelId = React.useId();
+  const toggle = () => setIsOpen((current) => !current);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") {
+      return;
+    }
+
+    event.preventDefault();
+    toggle();
+  };
+
+  return (
+    <Card
+      className={cn(
+        "overflow-hidden bg-[var(--surface)]/95 transition-[grid-column] duration-300 ease-out",
+        "md:data-[state=open]:col-span-2 xl:data-[state=open]:col-span-3",
+        className,
+      )}
+      data-state={isOpen ? "open" : "closed"}
+      data-storyline-id={dataStorylineId}
+      data-testid={testId}
+    >
+      <div
+        aria-controls={panelId}
+        aria-expanded={isOpen}
+        className="grid w-full cursor-pointer grid-cols-[1fr_auto] gap-4 p-6 text-left"
+        data-testid="storyline-toggle"
+        onClick={toggle}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+      >
+        <span className="min-w-0">{summary}</span>
+        <span
+          aria-hidden="true"
+          className={cn(
+            "grid size-8 shrink-0 place-items-center rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)] text-lg font-semibold text-[var(--text-muted)] transition-transform duration-300 ease-out",
+            isOpen && "rotate-45",
+          )}
+        >
+          +
+        </span>
+      </div>
+      <div
+        aria-hidden={!isOpen}
+        className={cn(
+          "grid overflow-hidden border-t transition-[grid-template-rows,opacity,border-color] duration-300 ease-out",
+          isOpen ? "border-[var(--border)] opacity-100" : "border-transparent opacity-0",
+        )}
+        data-state={isOpen ? "open" : "closed"}
+        data-testid="storyline-panel"
+        id={panelId}
+        style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <CardContent className={cn("grid gap-2 pt-4", contentClassName)} data-testid="storyline-item-grid">
+            {children}
+          </CardContent>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/ark-str-web-app/src/components/ui/disclosure-card.tsx
+++ b/ark-str-web-app/src/components/ui/disclosure-card.tsx
@@ -4,24 +4,28 @@ import * as React from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
-type DisclosureCardProps = {
+type DisclosureCardProps = Omit<React.HTMLAttributes<HTMLDivElement>, "children"> & {
   children: React.ReactNode;
-  className?: string;
   contentClassName?: string;
-  dataStorylineId: string;
+  contentTestId?: string;
+  defaultOpen?: boolean;
+  panelTestId?: string;
   summary: React.ReactNode;
-  testId: string;
+  toggleTestId?: string;
 };
 
 export function DisclosureCard({
   children,
   className,
   contentClassName,
-  dataStorylineId,
+  contentTestId,
+  defaultOpen = false,
+  panelTestId,
   summary,
-  testId,
+  toggleTestId,
+  ...props
 }: DisclosureCardProps) {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, setIsOpen] = React.useState(defaultOpen);
   const panelId = React.useId();
   const toggle = () => setIsOpen((current) => !current);
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -41,14 +45,13 @@ export function DisclosureCard({
         className,
       )}
       data-state={isOpen ? "open" : "closed"}
-      data-storyline-id={dataStorylineId}
-      data-testid={testId}
+      {...props}
     >
       <div
         aria-controls={panelId}
         aria-expanded={isOpen}
         className="grid w-full cursor-pointer grid-cols-[1fr_auto] gap-4 p-6 text-left"
-        data-testid="storyline-toggle"
+        data-testid={toggleTestId}
         onClick={toggle}
         onKeyDown={handleKeyDown}
         role="button"
@@ -72,12 +75,13 @@ export function DisclosureCard({
           isOpen ? "border-[var(--border)] opacity-100" : "border-transparent opacity-0",
         )}
         data-state={isOpen ? "open" : "closed"}
-        data-testid="storyline-panel"
+        data-testid={panelTestId}
         id={panelId}
+        inert={!isOpen ? true : undefined}
         style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
       >
         <div className="min-h-0 overflow-hidden">
-          <CardContent className={cn("grid gap-2 pt-4", contentClassName)} data-testid="storyline-item-grid">
+          <CardContent className={cn("grid gap-2 pt-4", contentClassName)} data-testid={contentTestId}>
             {children}
           </CardContent>
         </div>

--- a/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
@@ -3,6 +3,7 @@ import { ReaderPageFrame } from "@/components/layout/reader-page-frame";
 import type { FloatingAppBarModel } from "@/components/layout/types";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardTitle } from "@/components/ui/card";
+import { DisclosureCard } from "@/components/ui/disclosure-card";
 import { READER_LOCALE_LABELS } from "@/features/content/config/canonical-reader-locales";
 import { getReaderGroupHref } from "@/features/content/config/reader-routes";
 import type {
@@ -20,6 +21,8 @@ type ArchiveGroup = ContentGroupEntry & {
 type ArchiveStorylineItem = ContentStorylineItem & {
   group: ArchiveGroup;
 };
+
+const OPERATOR_STORYLINE_ID = "synthetic_operator_narratives";
 
 function formatMetric(value: number) {
   return new Intl.NumberFormat("ko-KR").format(value);
@@ -46,6 +49,69 @@ export function ReaderLocaleArchive({
       }),
     }))
     .filter((storyline) => storyline.items.length > 0);
+  const mainStorylines = archiveStorylines.filter(
+    (storyline) => storyline.storylineId !== OPERATOR_STORYLINE_ID,
+  );
+  const operatorStoryline =
+    archiveStorylines.find((storyline) => storyline.storylineId === OPERATOR_STORYLINE_ID) ?? null;
+
+  const renderStorylineSummary = (storyline: (typeof archiveStorylines)[number]) => (
+    <div className="grid gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={storyline.isSynthetic ? "default" : "accent"} className="w-fit">
+          {storyline.isSynthetic ? "Generated" : "Storyline"}
+        </Badge>
+        {storyline.storylineType ? <Badge variant="default">{storyline.storylineType}</Badge> : null}
+      </div>
+      <div className="space-y-2">
+        <CardTitle className="text-2xl">{storyline.title}</CardTitle>
+        <CardDescription>
+          <span className="block">
+            {storyline.primaryGroupCount} groups · {storyline.referenceCount} references
+          </span>
+          <span className="mt-1 block">
+            {formatMetric(storyline.totalVisibleCharacterCount)} chars · 약{" "}
+            {formatMetric(storyline.estimatedMinutes)}분
+          </span>
+        </CardDescription>
+      </div>
+    </div>
+  );
+
+  const renderStorylineItems = (storyline: (typeof archiveStorylines)[number]) =>
+    storyline.items.map((item) => {
+      const href = getReaderGroupHref(locale, item.group.groupId);
+
+      if (item.role === "reference") {
+        return (
+          <Link
+            key={`${storyline.storylineId}:${item.locationId ?? item.groupId}:${item.groupId}`}
+            className="block rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm font-semibold text-[var(--text-muted)] transition duration-[var(--motion-fast)] ease-out hover:border-[var(--accent)] hover:bg-[var(--accent-soft)] hover:text-[var(--text)]"
+            data-testid="storyline-reference-link"
+            href={href}
+          >
+            {item.displayTitle}
+          </Link>
+        );
+      }
+
+      return (
+        <Link
+          key={`${storyline.storylineId}:${item.groupId}`}
+          className="grid gap-3 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--panel)] p-4 text-[var(--text)] transition duration-[var(--motion-fast)] ease-out hover:-translate-y-px hover:border-[var(--accent)] hover:shadow-[var(--shadow-sm)]"
+          data-group-id={item.groupId}
+          data-testid="storyline-primary-card"
+          href={href}
+        >
+          <span className="text-base font-semibold leading-6">{item.group.title}</span>
+          <span className="grid grid-cols-3 gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            <span>{formatMetric(item.group.storyCount)} stories</span>
+            <span>{formatMetric(item.group.totalVisibleCharacterCount)} chars</span>
+            <span>약 {formatMetric(item.group.estimatedMinutes)}분</span>
+          </span>
+        </Link>
+      );
+    });
 
   return (
     <ReaderPageFrame
@@ -76,80 +142,35 @@ export function ReaderLocaleArchive({
       }
       testId="reader-shell"
     >
-      <section className="grid items-start gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {archiveStorylines.map((storyline) => {
+      <section className="grid items-start gap-4 md:grid-cols-2 xl:grid-cols-3" data-testid="storyline-grid">
+        {mainStorylines.map((storyline) => {
           return (
-            <Card
+            <DisclosureCard
               key={storyline.storylineId}
-              className="overflow-hidden bg-[var(--surface)]/95"
-              data-storyline-id={storyline.storylineId}
-              data-testid="storyline-section"
+              contentClassName="sm:grid-cols-2 2xl:grid-cols-3"
+              dataStorylineId={storyline.storylineId}
+              summary={renderStorylineSummary(storyline)}
+              testId="storyline-section"
             >
-              <details className="group">
-                <summary className="grid cursor-pointer gap-4 p-6 marker:hidden [&::-webkit-details-marker]:hidden">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant={storyline.isSynthetic ? "default" : "accent"} className="w-fit">
-                        {storyline.isSynthetic ? "Generated" : "Storyline"}
-                      </Badge>
-                      {storyline.storylineType ? <Badge variant="default">{storyline.storylineType}</Badge> : null}
-                    </div>
-                    <span
-                      aria-hidden="true"
-                      className="grid size-8 shrink-0 place-items-center rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)] text-lg font-semibold text-[var(--text-muted)] transition duration-[var(--motion-fast)] group-open:rotate-45"
-                    >
-                      +
-                    </span>
-                  </div>
-                  <div className="space-y-2">
-                    <CardTitle className="text-2xl">{storyline.title}</CardTitle>
-                    <CardDescription>
-                      {storyline.primaryGroupCount} groups · {storyline.referenceCount} references ·{" "}
-                      {formatMetric(storyline.totalVisibleCharacterCount)} chars · 약{" "}
-                      {formatMetric(storyline.estimatedMinutes)}분
-                    </CardDescription>
-                  </div>
-                </summary>
-                <CardContent className="grid gap-2 border-t border-[var(--border)] pt-4">
-                  {storyline.items.map((item) => {
-                    const href = getReaderGroupHref(locale, item.group.groupId);
-
-                    if (item.role === "reference") {
-                      return (
-                        <Link
-                          key={`${storyline.storylineId}:${item.locationId ?? item.groupId}:${item.groupId}`}
-                          className="block rounded-[var(--radius-sm)] border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-2 text-sm font-semibold text-[var(--text-muted)] transition duration-[var(--motion-fast)] ease-out hover:border-[var(--accent)] hover:bg-[var(--accent-soft)] hover:text-[var(--text)]"
-                          data-testid="storyline-reference-link"
-                          href={href}
-                        >
-                          {item.displayTitle}
-                        </Link>
-                      );
-                    }
-
-                    return (
-                      <Link
-                        key={`${storyline.storylineId}:${item.groupId}`}
-                        className="grid gap-3 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--panel)] p-4 text-[var(--text)] transition duration-[var(--motion-fast)] ease-out hover:-translate-y-px hover:border-[var(--accent)] hover:shadow-[var(--shadow-sm)]"
-                        data-group-id={item.groupId}
-                        data-testid="storyline-primary-card"
-                        href={href}
-                      >
-                        <span className="text-base font-semibold leading-6">{item.group.title}</span>
-                        <span className="grid grid-cols-3 gap-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
-                          <span>{formatMetric(item.group.storyCount)} stories</span>
-                          <span>{formatMetric(item.group.totalVisibleCharacterCount)} chars</span>
-                          <span>약 {formatMetric(item.group.estimatedMinutes)}분</span>
-                        </span>
-                      </Link>
-                    );
-                  })}
-                </CardContent>
-              </details>
-            </Card>
+              {renderStorylineItems(storyline)}
+            </DisclosureCard>
           );
         })}
       </section>
+
+      {operatorStoryline ? (
+        <section className="mt-2" data-testid="operator-storyline-section">
+          <DisclosureCard
+            className="md:data-[state=open]:col-span-1 xl:data-[state=open]:col-span-1"
+            contentClassName="sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
+            dataStorylineId={operatorStoryline.storylineId}
+            summary={renderStorylineSummary(operatorStoryline)}
+            testId="storyline-section"
+          >
+            {renderStorylineItems(operatorStoryline)}
+          </DisclosureCard>
+        </section>
+      ) : null}
     </ReaderPageFrame>
   );
 }

--- a/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
@@ -148,9 +148,12 @@ export function ReaderLocaleArchive({
             <DisclosureCard
               key={storyline.storylineId}
               contentClassName="sm:grid-cols-2 2xl:grid-cols-3"
-              dataStorylineId={storyline.storylineId}
+              contentTestId="storyline-item-grid"
+              data-storyline-id={storyline.storylineId}
+              data-testid="storyline-section"
+              panelTestId="storyline-panel"
               summary={renderStorylineSummary(storyline)}
-              testId="storyline-section"
+              toggleTestId="storyline-toggle"
             >
               {renderStorylineItems(storyline)}
             </DisclosureCard>
@@ -163,9 +166,12 @@ export function ReaderLocaleArchive({
           <DisclosureCard
             className="md:data-[state=open]:col-span-1 xl:data-[state=open]:col-span-1"
             contentClassName="sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
-            dataStorylineId={operatorStoryline.storylineId}
+            contentTestId="storyline-item-grid"
+            data-storyline-id={operatorStoryline.storylineId}
+            data-testid="storyline-section"
+            panelTestId="storyline-panel"
             summary={renderStorylineSummary(operatorStoryline)}
-            testId="storyline-section"
+            toggleTestId="storyline-toggle"
           >
             {renderStorylineItems(operatorStoryline)}
           </DisclosureCard>

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,7 +22,7 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - reader session persistence for preferred locale and last visited story
 - app-level light/dark theme toggle persisted through the preferences feature
 - canonical locale archive routes, group overview routes, and direct story deep links
-- locale archives render generated storyline sections as collapsed grid cards; expanded sections show primary groups and flow references as one chronological one-line list
+- locale archives render generated storyline sections as animated collapsed grid cards; expanded sections show primary groups and flow references as a chronological grid, while operator narratives sit in a bottom section
 - first-pass story body rendering sourced from bundled story detail JSON
 - a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -26,7 +26,7 @@ This v1 does not include:
 - visual tone: editorial archive
 - typography: sans-first, with display and body tokens kept in the same modern family
 - surface language: restrained radii and compact chrome instead of pill-heavy cards
-- archive surfaces: locale archive pages use collapsed storyline grid cards with compact chronological rows for primary groups and thinner flow-reference links
+- archive surfaces: locale archive pages use animated collapsed storyline grid cards, compact chronological item grids, thinner flow-reference links, and a separate bottom operator narrative section
 - story surfaces: dynamic story backdrops switch behind the content from intersecting background blocks while in-flow background cards keep uncropped image previews and dialogue cards prioritize body-first reading layouts
 - implementation base: shadcn-style shared primitives customized for this project
 - theme strategy: light and dark from the start

--- a/docs/exec-plans/completed/reader-archive-disclosure-polish.md
+++ b/docs/exec-plans/completed/reader-archive-disclosure-polish.md
@@ -1,0 +1,33 @@
+# Reader Archive Disclosure Polish
+
+## Objective
+
+Polish locale archive disclosure behavior and layout after the accordion archive refresh.
+
+## Scope
+
+- split storyline header metrics into group/reference and chars/time lines
+- animate storyline open and close over 300ms
+- move `오퍼레이터 서사` out of the main grid into a bottom section
+- render expanded storyline items as a responsive grid without changing item content
+
+## Constraints
+
+- keep archive data flow server-rendered
+- keep disclosure state local and non-persistent
+- keep routes and generated content unchanged
+- preserve existing primary and reference link destinations
+
+## Tasks
+
+- add a small client disclosure component under reader UI
+- refactor locale archive composition to separate operator narratives
+- update smoke coverage for grid exclusion, bottom operator section, and animated panels
+- update product/frontend/design docs and latest iteration record
+
+## Verification
+
+- `npm run app:typecheck`
+- `npm run app:lint`
+- `npm run verify`
+- `codex review --base main`

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,19 +1,19 @@
 # Latest Iteration
 
-Latest parent iteration: `#67`
+Latest parent iteration: `#70`
 
 Completed child issue:
 
-- `#68` - implement accordion storyline archive UI
+- `#71` - implement animated archive disclosure polish
 
 Current closeout outcome:
 
-- locale archive pages render storyline sections as initially collapsed grid cards
-- expanded storyline cards render primary groups and flow references in the same sorted one-line list
-- primary group rows link directly to group pages and show name, story count, visible characters, and estimated reading time
-- flow reference rows link directly to group pages and show only the reference name
-- `오퍼레이터 서사` is sorted as the final storyline
-- `npm run verify` passed on branch `codex-reader-archive-accordion-issue-68`
+- storyline cards split header metadata into group/reference and chars/time lines
+- storyline cards open and close with a 300ms local disclosure animation
+- expanded storyline cards render primary groups and flow references in a responsive grid
+- primary group and flow reference row contents are preserved from the prior archive iteration
+- `오퍼레이터 서사` is excluded from the main storyline grid and rendered as a bottom section
+- `npm run verify` passed on branch `codex-reader-archive-polish-issue-71`
 
 Remaining product gaps:
 

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -65,8 +65,8 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - locale-scoped character alias observation storage under `ark-str:character-observations:v1`
 - explicit empty summary state until the summary-generation issue lands, rendered below the story body instead of in a side rail
 - a floating rounded app bar shared by home, locale archive, group, and story pages
-- locale archives group story sets by generated storyline metadata in initially collapsed grid cards before routing into dedicated group overview pages
-- expanded storyline archive sections render `STORY_SET` primary groups and `BEFORE` / `AFTER` flow references in the same sorted list; `NONE/NONE` review groups are `오퍼레이터 서사`, unmatched event groups are `미분류`, and `오퍼레이터 서사` is sorted last
+- locale archives group story sets by generated storyline metadata in initially collapsed animated grid cards before routing into dedicated group overview pages
+- expanded storyline archive sections render `STORY_SET` primary groups and `BEFORE` / `AFTER` flow references in the same sorted grid; `NONE/NONE` review groups are `오퍼레이터 서사`, unmatched event groups are `미분류`, and `오퍼레이터 서사` is sorted last and rendered as a bottom section outside the main grid
 - generated group and story metrics for total visible characters and estimated reading time
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
 - story pages keep `background` blocks in the flow as scroll markers with bundled preview images shown uncropped while the backdrop updates from IntersectionObserver visibility

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -283,9 +283,11 @@ test.describe("reader shell smoke", () => {
       '[data-testid="storyline-primary-card"][data-group-id="main_0"]',
     );
     await expect(mainStorylinePanel).toHaveAttribute("aria-hidden", "true");
+    await expect(mainStorylinePanel).toHaveAttribute("inert", "");
     await mainStorylineSection.getByTestId("storyline-toggle").click();
     await expect(mainStorylinePanel).toHaveAttribute("data-state", "open");
     await expect(mainStorylinePanel).toHaveAttribute("aria-hidden", "false");
+    await expect(mainStorylinePanel).not.toHaveAttribute("inert", "");
     const panelTransitionDuration = await mainStorylinePanel.evaluate(
       (node) => window.getComputedStyle(node).transitionDuration,
     );

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -265,19 +265,33 @@ test.describe("reader shell smoke", () => {
     );
     await expect(mainStorylineSection).toBeVisible();
     await expect(mainStorylineSection.getByRole("heading", { name: "내일을 위하여" })).toBeVisible();
-    const storylineIds = await page.getByTestId("storyline-section").evaluateAll((nodes) =>
+    const storylineGrid = page.getByTestId("storyline-grid");
+    const storylineIds = await storylineGrid.getByTestId("storyline-section").evaluateAll((nodes) =>
       nodes.map((node) => node.getAttribute("data-storyline-id")),
     );
-    expect(storylineIds.at(-1)).toBe("synthetic_operator_narratives");
+    expect(storylineIds).not.toContain("synthetic_operator_narratives");
+    const operatorStorylineSection = page.getByTestId("operator-storyline-section");
+    await expect(
+      operatorStorylineSection.locator(
+        '[data-testid="storyline-section"][data-storyline-id="synthetic_operator_narratives"]',
+      ),
+    ).toBeVisible();
 
-    const mainStorylineDetails = mainStorylineSection.locator("details");
-    await expect(mainStorylineDetails).not.toHaveAttribute("open", "");
+    const mainStorylinePanel = mainStorylineSection.getByTestId("storyline-panel");
+    await expect(mainStorylinePanel).toHaveAttribute("data-state", "closed");
     const mainPrimaryRow = mainStorylineSection.locator(
       '[data-testid="storyline-primary-card"][data-group-id="main_0"]',
     );
-    await expect(mainPrimaryRow).toBeHidden();
-    await mainStorylineSection.locator("summary").click();
-    await expect(mainStorylineDetails).toHaveAttribute("open", "");
+    await expect(mainStorylinePanel).toHaveAttribute("aria-hidden", "true");
+    await mainStorylineSection.getByTestId("storyline-toggle").click();
+    await expect(mainStorylinePanel).toHaveAttribute("data-state", "open");
+    await expect(mainStorylinePanel).toHaveAttribute("aria-hidden", "false");
+    const panelTransitionDuration = await mainStorylinePanel.evaluate(
+      (node) => window.getComputedStyle(node).transitionDuration,
+    );
+    expect(panelTransitionDuration).toContain("0.3s");
+    const mainStorylineItemGrid = mainStorylineSection.getByTestId("storyline-item-grid");
+    await expect(mainStorylineItemGrid).toHaveCSS("display", "grid");
     await expect(mainPrimaryRow).toBeVisible();
     await expect(mainPrimaryRow).toHaveAttribute("href", `/ark-str/reader/kr/${koreanMainStorylinePrimary.groupId}/`);
     await expect(mainPrimaryRow).toContainText("stories");


### PR DESCRIPTION
## Summary
- Split storyline summary metadata into two lines so group/reference counts and char/time metrics read cleanly.
- Added a generic shared `DisclosureCard` primitive with 300ms open/close animation and closed-panel focus isolation.
- Rendered regular storylines in the main grid while moving `오퍼레이터 서사` into a separate bottom section with its own responsive grid.
- Updated smoke coverage and project docs for the new archive disclosure behavior.

## Validation
- `npm run verify`
- `codex review --base main`

Closes #71
Parent: #70