### PR TITLE
[codex] Keep regular archive sections as lists

### DIFF
--- a/ark-str-web-app/src/components/ui/disclosure-card.tsx
+++ b/ark-str-web-app/src/components/ui/disclosure-card.tsx
@@ -40,8 +40,7 @@ export function DisclosureCard({
   return (
     <Card
       className={cn(
-        "overflow-hidden bg-[var(--surface)]/95 transition-[grid-column] duration-300 ease-out",
-        "md:data-[state=open]:col-span-2 xl:data-[state=open]:col-span-3",
+        "overflow-hidden bg-[var(--surface)]/95",
         className,
       )}
       data-state={isOpen ? "open" : "closed"}
@@ -81,7 +80,7 @@ export function DisclosureCard({
         style={{ gridTemplateRows: isOpen ? "1fr" : "0fr" }}
       >
         <div className="min-h-0 overflow-hidden">
-          <CardContent className={cn("grid gap-2 pt-4", contentClassName)} data-testid={contentTestId}>
+          <CardContent className={cn("flex flex-col gap-2 pt-4", contentClassName)} data-testid={contentTestId}>
             {children}
           </CardContent>
         </div>

--- a/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
@@ -147,8 +147,7 @@ export function ReaderLocaleArchive({
           return (
             <DisclosureCard
               key={storyline.storylineId}
-              contentClassName="sm:grid-cols-2 2xl:grid-cols-3"
-              contentTestId="storyline-item-grid"
+              contentTestId="storyline-item-list"
               data-storyline-id={storyline.storylineId}
               data-testid="storyline-section"
               panelTestId="storyline-panel"
@@ -164,8 +163,7 @@ export function ReaderLocaleArchive({
       {operatorStoryline ? (
         <section className="mt-2" data-testid="operator-storyline-section">
           <DisclosureCard
-            className="md:data-[state=open]:col-span-1 xl:data-[state=open]:col-span-1"
-            contentClassName="sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
+            contentClassName="grid sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
             contentTestId="storyline-item-grid"
             data-storyline-id={operatorStoryline.storylineId}
             data-testid="storyline-section"

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,7 +22,7 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - reader session persistence for preferred locale and last visited story
 - app-level light/dark theme toggle persisted through the preferences feature
 - canonical locale archive routes, group overview routes, and direct story deep links
-- locale archives render generated storyline sections as animated collapsed grid cards; expanded sections show primary groups and flow references as a chronological grid, while operator narratives sit in a bottom section
+- locale archives render generated storyline sections as animated collapsed grid cards; regular storyline cards stay inside the main grid as single cells whether closed or open, expanded regular sections keep a simple one-column list, and operator narratives sit in a separate bottom section with an internal grid
 - first-pass story body rendering sourced from bundled story detail JSON
 - a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -26,7 +26,7 @@ This v1 does not include:
 - visual tone: editorial archive
 - typography: sans-first, with display and body tokens kept in the same modern family
 - surface language: restrained radii and compact chrome instead of pill-heavy cards
-- archive surfaces: locale archive pages use animated collapsed storyline grid cards, compact chronological item grids, thinner flow-reference links, and a separate bottom operator narrative section
+- archive surfaces: locale archive pages use animated collapsed storyline grid cards that keep their grid cell when expanded, simple regular storyline item lists, thinner flow-reference links, and a separate bottom operator narrative grid section
 - story surfaces: dynamic story backdrops switch behind the content from intersecting background blocks while in-flow background cards keep uncropped image previews and dialogue cards prioritize body-first reading layouts
 - implementation base: shadcn-style shared primitives customized for this project
 - theme strategy: light and dark from the start

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -11,8 +11,9 @@ Current shared primitives live in `ark-str-web-app/src/components/ui/`.
 - `Checkbox`
 - `Badge`
 - `Separator`
+- `DisclosureCard`
 
-These are the base layer that features should compose before adding their own product-specific UI.
+These are the base layer that features should compose before adding their own product-specific UI. `DisclosureCard` owns only generic open/close behavior and must not encode feature-specific grid spanning.
 
 ## Product Patterns
 

--- a/docs/exec-plans/completed/archive-disclosure-grid-span-fix.md
+++ b/docs/exec-plans/completed/archive-disclosure-grid-span-fix.md
@@ -1,0 +1,39 @@
+# Archive Disclosure Grid Span Fix
+
+## Objective
+
+Keep regular storyline disclosure cards inside the locale archive grid in both closed and open states, while keeping only `오퍼레이터 서사` in the separate bottom section.
+
+## Scope
+
+- Remove default open-state column spanning from the shared disclosure primitive.
+- Restore regular storyline expanded contents to a simple one-column list.
+- Keep operator narrative expanded contents as the only multi-column grid.
+- Add smoke coverage for regular storyline grid placement and list layout after opening.
+
+## Constraints
+
+- Do not change content indexing or generated assets.
+- Keep `오퍼레이터 서사` outside the main storyline grid.
+- Preserve the 300ms panel open/close animation.
+- End with `npm run verify` and PR review.
+
+## Tasks
+
+- [x] Patch `DisclosureCard` default layout classes.
+- [x] Patch `ReaderLocaleArchive` regular and operator section content layouts.
+- [x] Extend smoke test assertions for regular list layout and operator grid layout.
+- [x] Update GitHub issue metadata, relevant docs, and iteration report.
+- [x] Verify the corrected layout locally.
+
+## Verification
+
+- `npm run app:typecheck`
+- `npm run app:lint`
+- `npm run verify`
+- `codex review --base main`
+
+## Decision Log
+
+- 2026-04-22: Only the synthetic operator narrative section should leave the main grid; regular storyline cards must remain one grid cell when expanded.
+- 2026-04-22: Regular storyline expanded contents must stay as a simple list; only the operator narrative bottom section uses an internal grid.

--- a/docs/generated/latest-iteration.md
+++ b/docs/generated/latest-iteration.md
@@ -1,19 +1,19 @@
 # Latest Iteration
 
-Latest parent iteration: `#70`
+Latest parent iteration: `#73`
 
 Completed child issue:
 
-- `#71` - implement animated archive disclosure polish
+- `#74` - fix regular archive card grid span
 
 Current closeout outcome:
 
-- storyline cards split header metadata into group/reference and chars/time lines
-- storyline cards open and close with a 300ms local disclosure animation
-- expanded storyline cards render primary groups and flow references in a responsive grid
-- primary group and flow reference row contents are preserved from the prior archive iteration
-- `오퍼레이터 서사` is excluded from the main storyline grid and rendered as a bottom section
-- `npm run verify` passed on branch `codex-reader-archive-polish-issue-71`
+- regular storyline cards stay inside the main grid as one cell whether closed or open
+- only `오퍼레이터 서사` is excluded from the main storyline grid and rendered as a bottom section
+- expanded regular storyline contents stay as a simple one-column list
+- the bottom `오퍼레이터 서사` section keeps an internal responsive grid
+- smoke coverage now checks the open regular card grid placement, regular list layout, and operator grid layout
+- `npm run verify` passed on branch `codex-archive-grid-span-issue-74`
 
 Remaining product gaps:
 

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -65,8 +65,8 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - locale-scoped character alias observation storage under `ark-str:character-observations:v1`
 - explicit empty summary state until the summary-generation issue lands, rendered below the story body instead of in a side rail
 - a floating rounded app bar shared by home, locale archive, group, and story pages
-- locale archives group story sets by generated storyline metadata in initially collapsed animated grid cards before routing into dedicated group overview pages
-- expanded storyline archive sections render `STORY_SET` primary groups and `BEFORE` / `AFTER` flow references in the same sorted grid; `NONE/NONE` review groups are `오퍼레이터 서사`, unmatched event groups are `미분류`, and `오퍼레이터 서사` is sorted last and rendered as a bottom section outside the main grid
+- locale archives group story sets by generated storyline metadata in initially collapsed animated grid cards that remain one main-grid cell whether closed or open before routing into dedicated group overview pages
+- expanded regular storyline archive sections render `STORY_SET` primary groups and `BEFORE` / `AFTER` flow references in the same sorted one-column list; `NONE/NONE` review groups are `오퍼레이터 서사`, unmatched event groups are `미분류`, and `오퍼레이터 서사` is sorted last and rendered as a bottom section outside the main grid with an internal group grid
 - generated group and story metrics for total visible characters and estimated reading time
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
 - story pages keep `background` blocks in the flow as scroll markers with bundled preview images shown uncropped while the backdrop updates from IntersectionObserver visibility

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -288,12 +288,24 @@ test.describe("reader shell smoke", () => {
     await expect(mainStorylinePanel).toHaveAttribute("data-state", "open");
     await expect(mainStorylinePanel).toHaveAttribute("aria-hidden", "false");
     await expect(mainStorylinePanel).not.toHaveAttribute("inert", "");
+    const mainStorylineGridPlacement = await mainStorylineSection.evaluate((node) => {
+      const styles = window.getComputedStyle(node);
+      return {
+        gridColumnEnd: styles.gridColumnEnd,
+        gridColumnStart: styles.gridColumnStart,
+      };
+    });
+    expect(mainStorylineGridPlacement).toEqual({
+      gridColumnEnd: "auto",
+      gridColumnStart: "auto",
+    });
     const panelTransitionDuration = await mainStorylinePanel.evaluate(
       (node) => window.getComputedStyle(node).transitionDuration,
     );
     expect(panelTransitionDuration).toContain("0.3s");
-    const mainStorylineItemGrid = mainStorylineSection.getByTestId("storyline-item-grid");
-    await expect(mainStorylineItemGrid).toHaveCSS("display", "grid");
+    const mainStorylineItemList = mainStorylineSection.getByTestId("storyline-item-list");
+    await expect(mainStorylineItemList).toHaveCSS("display", "flex");
+    await expect(mainStorylineItemList).toHaveCSS("flex-direction", "column");
     await expect(mainPrimaryRow).toBeVisible();
     await expect(mainPrimaryRow).toHaveAttribute("href", `/ark-str/reader/kr/${koreanMainStorylinePrimary.groupId}/`);
     await expect(mainPrimaryRow).toContainText("stories");
@@ -311,6 +323,9 @@ test.describe("reader shell smoke", () => {
         '[data-testid="storyline-section"][data-storyline-id="synthetic_operator_narratives"]',
       ),
     ).toContainText("오퍼레이터 서사");
+    const operatorStorylineGrid = operatorStorylineSection.getByTestId("storyline-item-grid");
+    await operatorStorylineSection.getByTestId("storyline-toggle").click();
+    await expect(operatorStorylineGrid).toHaveCSS("display", "grid");
     await expect(
       page.locator('[data-testid="storyline-section"][data-storyline-id="synthetic_uncategorized"]'),
     ).toContainText("미분류");


### PR DESCRIPTION
## Summary
- Removed open-state column spanning from `DisclosureCard` so regular storyline cards remain one main-grid cell when opened.
- Changed `DisclosureCard` content default to a vertical list and kept only the bottom `오퍼레이터 서사` section on an internal responsive grid.
- Updated smoke coverage to assert regular open cards keep `grid-column: auto`, regular contents are flex-column lists, and operator contents are grid.
- Updated frontend/product/design docs and the iteration plan/report to match the corrected contract.

## Validation
- `npm run app:typecheck`
- `npm run app:lint`
- `npm run verify`
- `codex review --base main`

Closes #74
Parent: #73