### PR TITLE
Refresh reader group page UI

### DIFF
--- a/ark-str-web-app/src/app/reader/[locale]/[groupId]/page.tsx
+++ b/ark-str-web-app/src/app/reader/[locale]/[groupId]/page.tsx
@@ -16,9 +16,31 @@ import {
   readContentIndex,
   resolvePublicAssetPath,
 } from "@/features/content/service/read-content-index";
+import type { ContentStorylineItem } from "@/features/content/types";
 import { ReaderGroupOverview } from "@/features/reader/ui/reader-group-overview";
 
 export const dynamicParams = false;
+
+const GROUP_FLOW_ITEM_LIMIT = 24;
+
+function selectGroupFlowItems(items: ContentStorylineItem[], currentGroupId: string): ContentStorylineItem[] {
+  if (items.length <= GROUP_FLOW_ITEM_LIMIT) {
+    return items;
+  }
+
+  const currentIndex = items.findIndex((item) => item.groupId === currentGroupId);
+  if (currentIndex < 0) {
+    return items.slice(0, GROUP_FLOW_ITEM_LIMIT);
+  }
+
+  const beforeCount = Math.floor((GROUP_FLOW_ITEM_LIMIT - 1) / 2);
+  const start = Math.max(
+    0,
+    Math.min(currentIndex - beforeCount, items.length - GROUP_FLOW_ITEM_LIMIT),
+  );
+
+  return items.slice(start, start + GROUP_FLOW_ITEM_LIMIT);
+}
 
 export function generateStaticParams() {
   return getReaderGroupStaticParams();
@@ -51,8 +73,9 @@ export default async function ReaderGroupPage({
     ...group,
     backgroundImageHref: resolvePublicAssetPath(group.backgroundImagePath),
   };
-  const groupFlowItems = (
-    primaryStoryline?.items ?? [
+  const selectedStorylineItems = primaryStoryline
+    ? selectGroupFlowItems(primaryStoryline.items, groupId)
+    : [
       {
         displayTitle: group.title,
         groupId,
@@ -62,8 +85,8 @@ export default async function ReaderGroupPage({
         sortKey: 0,
         storySetId: null,
       },
-    ]
-  ).flatMap((item, index) => {
+    ];
+  const groupFlowItems = selectedStorylineItems.flatMap((item, index) => {
     const itemGroup = groupsById.get(item.groupId);
     if (!itemGroup) {
       return [];

--- a/ark-str-web-app/src/app/reader/[locale]/[groupId]/page.tsx
+++ b/ark-str-web-app/src/app/reader/[locale]/[groupId]/page.tsx
@@ -7,7 +7,10 @@ import {
 import {
   buildLocaleSwitchHref,
   findGroupEntry,
+  getLocaleGroups,
+  getLocaleStorylines,
   getGroupStories,
+  getReaderGroupHref,
   getReaderGroupStaticParams,
   getReaderLocaleHref,
   readContentIndex,
@@ -39,10 +42,46 @@ export default async function ReaderGroupPage({
   }
 
   const stories = getGroupStories(index, locale, groupId);
+  const groupsById = new Map(getLocaleGroups(index, locale).map((item) => [item.groupId, item]));
+  const primaryStoryline =
+    getLocaleStorylines(index, locale).find((storyline) =>
+      storyline.items.some((item) => item.role === "primary" && item.groupId === groupId),
+    ) ?? null;
   const groupWithAssets = {
     ...group,
     backgroundImageHref: resolvePublicAssetPath(group.backgroundImagePath),
   };
+  const groupFlowItems = (
+    primaryStoryline?.items ?? [
+      {
+        displayTitle: group.title,
+        groupId,
+        locationId: null,
+        locationType: null,
+        role: "primary" as const,
+        sortKey: 0,
+        storySetId: null,
+      },
+    ]
+  ).flatMap((item, index) => {
+    const itemGroup = groupsById.get(item.groupId);
+    if (!itemGroup) {
+      return [];
+    }
+
+    return [
+      {
+        backgroundImageAspect: itemGroup.backgroundImageAspect,
+        backgroundImageHref: resolvePublicAssetPath(itemGroup.backgroundImagePath),
+        displayTitle: item.displayTitle || itemGroup.title,
+        groupId: item.groupId,
+        href: getReaderGroupHref(locale, item.groupId),
+        isCurrent: item.groupId === groupId,
+        itemKey: `${item.locationId ?? item.storySetId ?? item.groupId}:${item.role}:${index}`,
+        role: item.role,
+      },
+    ];
+  });
 
   return (
     <ReaderGroupOverview
@@ -61,6 +100,8 @@ export default async function ReaderGroupPage({
         storySelect: null,
       }}
       group={groupWithAssets}
+      groupFlowItems={groupFlowItems}
+      storylineTitle={primaryStoryline?.title ?? group.title}
       locale={locale}
       stories={stories}
     />

--- a/ark-str-web-app/src/features/reader/ui/reader-group-overview.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-group-overview.tsx
@@ -2,10 +2,11 @@ import Link from "next/link";
 import { ReaderPageFrame } from "@/components/layout/reader-page-frame";
 import type { FloatingAppBarModel } from "@/components/layout/types";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
 import type { ReaderLocale } from "@/features/content/types";
-import type { ContentGroupEntry, ContentStoryIndexEntry } from "@/features/content/types";
+import type { ContentGroupEntry, ContentStoryIndexEntry, ContentStorylineItemRole } from "@/features/content/types";
 import { getReaderStoryHref } from "@/features/content/config/reader-routes";
+import { cn } from "@/lib/utils";
 
 function formatMetric(value: number) {
   return new Intl.NumberFormat("ko-KR").format(value);
@@ -17,18 +18,59 @@ function getGroupHeroImageClassName(backgroundImageAspect: ContentGroupEntry["ba
     : "h-full w-full object-cover object-center";
 }
 
+function getFlowCardImageClassName(backgroundImageAspect: ContentGroupEntry["backgroundImageAspect"]) {
+  return backgroundImageAspect === "square"
+    ? "absolute inset-0 h-full w-full object-contain object-center p-5 opacity-75 blur-[0.5px]"
+    : "absolute inset-0 h-full w-full scale-110 object-cover object-center opacity-70 blur-[1px]";
+}
+
+function ArrowUpRightIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3.5 w-3.5 shrink-0"
+      fill="none"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M4.25 11.75 11.5 4.5m0 0H5.75m5.75 0v5.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.7"
+      />
+    </svg>
+  );
+}
+
 type GroupWithAssets = ContentGroupEntry & {
   backgroundImageHref: string | null;
+};
+
+type GroupFlowItem = {
+  backgroundImageAspect: ContentGroupEntry["backgroundImageAspect"];
+  backgroundImageHref: string | null;
+  displayTitle: string;
+  groupId: string;
+  href: string;
+  isCurrent: boolean;
+  itemKey: string;
+  role: ContentStorylineItemRole;
 };
 
 export function ReaderGroupOverview({
   appBar,
   group,
+  groupFlowItems,
+  storylineTitle,
   locale,
   stories,
 }: {
   appBar: FloatingAppBarModel;
   group: GroupWithAssets;
+  groupFlowItems: GroupFlowItem[];
+  storylineTitle: string;
   locale: ReaderLocale;
   stories: ContentStoryIndexEntry[];
 }) {
@@ -39,7 +81,7 @@ export function ReaderGroupOverview({
         <section>
           <Card className="overflow-hidden border-[var(--border)] bg-[var(--surface)]/92 shadow-[var(--shadow-sm)]">
             <div
-              className="relative aspect-[16/7] min-h-52 overflow-hidden bg-[var(--surface-muted)]"
+              className="relative flex aspect-[16/7] min-h-72 items-end justify-center overflow-hidden bg-[var(--surface-muted)]"
               data-testid="group-hero-image"
             >
               {group.backgroundImageHref ? (
@@ -49,86 +91,128 @@ export function ReaderGroupOverview({
                     alt=""
                     aria-hidden="true"
                     className={getGroupHeroImageClassName(group.backgroundImageAspect)}
+                    decoding="async"
                     src={group.backgroundImageHref}
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-[var(--surface)]/88 via-[var(--surface)]/12 to-transparent" />
+                  <div className="absolute inset-0 bg-gradient-to-t from-black/72 via-black/18 to-transparent" />
                 </>
               ) : (
                 <div className="h-full w-full bg-[radial-gradient(circle_at_top_left,var(--accent-soft),transparent_42%),linear-gradient(135deg,var(--surface-muted),var(--panel))]" />
               )}
-            </div>
-            <CardContent className="grid gap-5 p-5 md:p-7">
-              <div className="grid gap-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant="accent" className="w-fit">
-                    Group overview
-                  </Badge>
-                  <Badge variant="default">{group.entryType ?? "GROUP"}</Badge>
-                  {group.actType ? <Badge variant="default">{group.actType}</Badge> : null}
-                </div>
-                <h1 className="font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.03em] md:text-5xl">
+              <div className="absolute inset-x-0 bottom-0 z-10 grid justify-items-center gap-4 px-5 pb-7 pt-20 text-center text-white md:px-8 md:pb-9">
+                <h1 className="max-w-4xl font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.04em] md:text-6xl">
                   {group.title}
                 </h1>
-              </div>
-              <div className="grid gap-3 md:grid-cols-3" data-testid="group-stats">
-                <div className="rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--panel)] px-4 py-3">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                    Stories
-                  </p>
-                  <p className="mt-1 text-2xl font-semibold text-[var(--text)]">
-                    {formatMetric(group.storyCount)}
-                  </p>
-                </div>
-                <div className="rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--panel)] px-4 py-3">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                    Characters
-                  </p>
-                  <p className="mt-1 text-2xl font-semibold text-[var(--text)]">
-                    {formatMetric(group.totalVisibleCharacterCount)}
-                  </p>
-                </div>
-                <div className="rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--panel)] px-4 py-3">
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
-                    Reading Time
-                  </p>
-                  <p className="mt-1 text-2xl font-semibold text-[var(--text)]">
+                <div
+                  className="flex flex-wrap justify-center gap-2 text-[11px] font-semibold uppercase tracking-[0.14em]"
+                  data-testid="group-stats"
+                >
+                  <span className="rounded-full border border-white/20 bg-black/35 px-3 py-1.5 backdrop-blur-md">
+                    {formatMetric(group.storyCount)} Stories
+                  </span>
+                  <span className="rounded-full border border-white/20 bg-black/35 px-3 py-1.5 backdrop-blur-md">
+                    {formatMetric(group.totalVisibleCharacterCount)} chars
+                  </span>
+                  <span className="rounded-full border border-white/20 bg-black/35 px-3 py-1.5 backdrop-blur-md">
                     약 {formatMetric(group.estimatedMinutes)}분
-                  </p>
+                  </span>
                 </div>
               </div>
-            </CardContent>
+            </div>
           </Card>
         </section>
       }
       testId="group-shell"
     >
+      <section className="grid gap-3" data-testid="group-flow-nav">
+        <div className="flex items-end justify-between gap-4">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">
+            {storylineTitle}
+          </h2>
+          <span className="text-xs text-[var(--text-muted)]">
+            {formatMetric(groupFlowItems.length)} groups
+          </span>
+        </div>
+        <div className="-mx-4 flex gap-3 overflow-x-auto px-4 py-2 md:mx-0 md:px-2">
+          {groupFlowItems.map((item) => (
+            <Link
+              key={item.itemKey}
+              aria-current={item.isCurrent ? "page" : undefined}
+              className={cn(
+                "group relative grid h-28 w-56 shrink-0 content-end overflow-hidden rounded-[var(--radius-md)] border bg-black/80 p-4 text-white shadow-[var(--shadow-sm)] transition duration-[var(--motion-fast)] ease-out hover:-translate-y-px hover:border-[var(--accent)]",
+                item.isCurrent
+                  ? "border-[var(--accent)] ring-2 ring-[var(--accent)]/35"
+                  : "border-white/10",
+              )}
+              data-current={item.isCurrent ? "true" : "false"}
+              data-group-id={item.groupId}
+              data-role={item.role}
+              data-testid="group-flow-card"
+              href={item.href}
+            >
+              {item.backgroundImageHref ? (
+                <>
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    alt=""
+                    aria-hidden="true"
+                    className={getFlowCardImageClassName(item.backgroundImageAspect)}
+                    data-testid="group-flow-card-image"
+                    decoding="async"
+                    loading="lazy"
+                    src={item.backgroundImageHref}
+                  />
+                  <span className="absolute inset-0 bg-black/36" aria-hidden="true" />
+                  <span className="absolute inset-0 bg-gradient-to-t from-black/78 via-black/34 to-black/10" aria-hidden="true" />
+                </>
+              ) : (
+                <span className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--accent)_30%,transparent),transparent_42%),linear-gradient(135deg,black,color-mix(in_srgb,var(--text)_18%,black))]" />
+              )}
+              <span
+                className="relative z-10 inline-flex items-center gap-1.5 text-base font-semibold leading-6 text-white drop-shadow-md"
+                data-testid="group-flow-card-title"
+              >
+                {item.displayTitle}
+                {item.role === "reference" ? <ArrowUpRightIcon /> : null}
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
       <section className="grid gap-4">
         {stories.map((story) => (
-          <Card key={story.storyId} className="bg-[var(--surface)]/94">
-            <CardHeader>
-              <div className="flex flex-wrap items-center gap-2">
-                {story.storyCode ? <Badge variant="default">{story.storyCode}</Badge> : null}
-                {story.avgTag ? <Badge variant="default">{story.avgTag}</Badge> : null}
-              </div>
-              <CardTitle className="text-3xl">{story.title}</CardTitle>
-              <CardDescription>{story.stageId ?? story.storyId}</CardDescription>
-            </CardHeader>
-            <CardContent className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-              <div className="grid gap-2 text-sm text-[var(--text-muted)] md:grid-cols-3">
-                <span>{formatMetric(story.visibleCharacterCount)} chars</span>
-                <span>약 {formatMetric(story.estimatedMinutes)}분</span>
-                <span>{story.bodyAvailable ? "Bundled body ready" : "Body pending"}</span>
-              </div>
-              <div className="flex flex-wrap gap-3">
-                <Link
-                  className="inline-flex items-center justify-center rounded-[var(--radius-md)] border border-[var(--accent)] bg-[var(--accent)] px-4 py-2.5 text-sm font-semibold text-[var(--accent-contrast)] shadow-[var(--shadow-sm)] transition duration-[var(--motion-fast)] ease-out hover:-translate-y-px hover:border-[var(--accent-strong)] hover:bg-[var(--accent-strong)]"
-                  href={getReaderStoryHref(locale, story.groupId, story.storyId)}
+          <Link
+            key={story.storyId}
+            className="group block"
+            data-testid="group-story-card"
+            href={getReaderStoryHref(locale, story.groupId, story.storyId)}
+          >
+            <Card className="bg-[var(--surface)]/94 transition duration-[var(--motion-fast)] ease-out group-hover:-translate-y-px group-hover:border-[var(--accent)] group-hover:shadow-[var(--shadow-sm)]">
+              <CardHeader className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+                <div className="grid gap-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    {story.storyCode ? <Badge variant="default">{story.storyCode}</Badge> : null}
+                    {story.avgTag ? <Badge variant="default">{story.avgTag}</Badge> : null}
+                  </div>
+                  <div className="grid gap-1">
+                    <CardTitle className="text-3xl">{story.title}</CardTitle>
+                  </div>
+                </div>
+                <div
+                  className="flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)] md:justify-end"
+                  data-testid="group-story-metrics"
                 >
-                  Open story
-                </Link>
-              </div>
-            </CardContent>
-          </Card>
+                  <span className="rounded-full border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-1.5">
+                    {formatMetric(story.visibleCharacterCount)} chars
+                  </span>
+                  <span className="rounded-full border border-[var(--border)] bg-[var(--surface-muted)] px-3 py-1.5">
+                    약 {formatMetric(story.estimatedMinutes)}분
+                  </span>
+                </div>
+              </CardHeader>
+            </Card>
+          </Link>
         ))}
       </section>
     </ReaderPageFrame>

--- a/ark-str-web-app/src/features/reader/ui/reader-group-overview.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-group-overview.tsx
@@ -97,7 +97,7 @@ export function ReaderGroupOverview({
                   <div className="absolute inset-0 bg-gradient-to-t from-black/72 via-black/18 to-transparent" />
                 </>
               ) : (
-                <div className="h-full w-full bg-[radial-gradient(circle_at_top_left,var(--accent-soft),transparent_42%),linear-gradient(135deg,var(--surface-muted),var(--panel))]" />
+                <div className="h-full w-full bg-[radial-gradient(circle_at_top_left,color-mix(in_srgb,var(--accent)_28%,transparent),transparent_42%),linear-gradient(135deg,black,color-mix(in_srgb,var(--text)_18%,black))]" />
               )}
               <div className="absolute inset-x-0 bottom-0 z-10 grid justify-items-center gap-4 px-5 pb-7 pt-20 text-center text-white md:px-8 md:pb-9">
                 <h1 className="max-w-4xl font-[var(--font-display)] text-4xl font-semibold leading-tight tracking-[-0.04em] md:text-6xl">

--- a/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-locale-archive.tsx
@@ -31,11 +31,11 @@ function formatMetric(value: number) {
 
 function getArchiveCardBackgroundClassName(backgroundImageAspect: ContentGroupEntry["backgroundImageAspect"]) {
   const sharedClassName =
-    "absolute inset-0 h-full w-full transition duration-[var(--motion-fast)] ease-out group-hover:opacity-[0.38]";
+    "absolute inset-0 h-full w-full transition duration-[var(--motion-fast)] ease-out group-hover:opacity-[0.78]";
 
   return backgroundImageAspect === "square"
-    ? `${sharedClassName} object-contain p-5 opacity-[0.34] blur-[1px]`
-    : `${sharedClassName} scale-105 object-cover opacity-[0.28] blur-[2px]`;
+    ? `${sharedClassName} object-contain p-5 opacity-75 blur-[0.5px]`
+    : `${sharedClassName} scale-105 object-cover opacity-70 blur-[1px]`;
 }
 
 export function ReaderLocaleArchive({
@@ -108,7 +108,7 @@ export function ReaderLocaleArchive({
       return (
         <Link
           key={`${storyline.storylineId}:${item.groupId}`}
-          className="group relative grid min-h-28 overflow-hidden rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--panel)] p-4 text-[var(--text)] transition duration-[var(--motion-fast)] ease-out hover:-translate-y-px hover:border-[var(--accent)] hover:shadow-[var(--shadow-sm)]"
+          className="group relative grid min-h-28 content-start gap-4 overflow-hidden rounded-[var(--radius-md)] border border-white/10 bg-black/80 p-5 text-white transition duration-[var(--motion-fast)] ease-out hover:-translate-y-px hover:border-[var(--accent)] hover:shadow-[var(--shadow-sm)]"
           data-group-id={item.groupId}
           data-testid="storyline-primary-card"
           href={href}
@@ -125,15 +125,29 @@ export function ReaderLocaleArchive({
                 loading="lazy"
                 src={item.group.backgroundImageHref}
               />
-              <span className="absolute inset-0 bg-[var(--panel)]/72" aria-hidden="true" />
-              <span className="absolute inset-0 bg-gradient-to-br from-[var(--panel)]/92 via-[var(--panel)]/60 to-[var(--accent-soft)]/35" aria-hidden="true" />
+              <span className="absolute inset-0 bg-black/36" aria-hidden="true" />
+              <span className="absolute inset-0 bg-gradient-to-br from-black/78 via-black/34 to-black/10" aria-hidden="true" />
             </>
           ) : null}
-          <span className="relative z-10 text-base font-semibold leading-6">{item.group.title}</span>
-          <span className="relative z-10 grid gap-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)] sm:grid-cols-3 sm:gap-2">
-            <span>{formatMetric(item.group.storyCount)} stories</span>
-            <span>{formatMetric(item.group.totalVisibleCharacterCount)} chars</span>
-            <span>약 {formatMetric(item.group.estimatedMinutes)}분</span>
+          <span
+            className="relative z-10 text-base font-semibold leading-6 text-white drop-shadow-md"
+            data-testid="storyline-primary-card-title"
+          >
+            {item.group.title}
+          </span>
+          <span
+            className="relative z-10 flex flex-wrap gap-x-2 gap-y-1.5 text-[11px] font-semibold uppercase tracking-[0.12em] text-white/80"
+            data-testid="storyline-primary-card-metrics"
+          >
+            <span className="inline-flex h-7 items-center rounded-full border border-white/15 bg-black/35 px-3">
+              {formatMetric(item.group.storyCount)} stories
+            </span>
+            <span className="inline-flex h-7 items-center rounded-full border border-white/15 bg-black/35 px-3">
+              {formatMetric(item.group.totalVisibleCharacterCount)} chars
+            </span>
+            <span className="inline-flex h-7 items-center rounded-full border border-white/15 bg-black/35 px-3">
+              약 {formatMetric(item.group.estimatedMinutes)}분
+            </span>
           </span>
         </Link>
       );

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -27,7 +27,7 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - first-pass story body rendering sourced from bundled story detail JSON
 - a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button
-- group overview pages render title and Stories/chars/time metrics over the generated hero image, then show the named current storyline as horizontally scrollable group/reference cards before simplified story cards; reference cards carry an up-right cue and story cards avoid exposing internal story IDs
+- group overview pages render title and Stories/chars/time metrics over the generated hero image, then show the named current storyline as horizontally scrollable group/reference cards before simplified story cards; oversized storylines are bounded to the current group neighborhood, reference cards carry an up-right cue, and story cards avoid exposing internal story IDs
 - story-only dynamic backdrops driven directly by intersecting bundled background blocks, while non-story pages keep the archive base background
 - in-flow background blocks keep their own bundled image previews without cropping and still drive the fixed story backdrop
 - story backdrop swaps on story pages happen immediately without cross-fade state

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -23,11 +23,11 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - app-level light/dark theme toggle persisted through the preferences feature
 - canonical locale archive routes, group overview routes, and direct story deep links
 - locale archives render generated storyline sections as animated collapsed grid cards; regular storyline cards stay inside the main grid as single cells whether closed or open, expanded regular sections keep a simple one-column list, and operator narratives sit in a separate bottom section with an internal grid
-- locale archive primary group cards may include generated group images sourced first from `assets/group-backgrounds/<groupId>.png`; square MAINLINE artwork is contained and wide ACTIVITY artwork is used as a soft card background
+- locale archive primary group cards use the same dark image treatment as group-flow cards, with white titles and Stories/chars/time metrics rendered as compact pill badges
 - first-pass story body rendering sourced from bundled story detail JSON
 - a restrained floating app bar shared by home, archive, group, and story routes
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button
-- group overview pages render the generated group image above the title and metrics when one is available
+- group overview pages render title and Stories/chars/time metrics over the generated hero image, then show the named current storyline as horizontally scrollable group/reference cards before simplified story cards; reference cards carry an up-right cue and story cards avoid exposing internal story IDs
 - story-only dynamic backdrops driven directly by intersecting bundled background blocks, while non-story pages keep the archive base background
 - in-flow background blocks keep their own bundled image previews without cropping and still drive the fixed story backdrop
 - story backdrop swaps on story pages happen immediately without cross-fade state

--- a/docs/exec-plans/completed/group-page-ui-refresh.md
+++ b/docs/exec-plans/completed/group-page-ui-refresh.md
@@ -1,0 +1,32 @@
+# Group Page UI Refresh
+
+## Objective
+
+Refresh reader group overview pages so the page reads as a visual story set hub instead of a metadata-heavy index.
+
+## Scope
+
+- Move title and Stories/chars/time metrics onto the hero image, center-bottom aligned.
+- Remove group overview/type badges from the hero.
+- Add a horizontal storyline flow section under the hero using the current group's primary storyline.
+- Include both primary group and reference items in the flow, with the current group highlighted.
+- Use the storyline title as the flow heading and mark reference items with an up-right cue.
+- Simplify story cards by removing the explicit `Open story` CTA and body readiness copy.
+- Hide internal story identifiers from story cards.
+
+## Constraints
+
+- Keep runtime assets bundled.
+- Reuse existing generated content schema.
+- Preserve static export and smoke coverage.
+
+## Verification
+
+- `npm run app:typecheck`
+- `npm run app:lint`
+- `npm run verify`
+
+## Decision Log
+
+- The flow section uses the current group's primary storyline as the previous/next context.
+- Story cards remain navigable by making the full card a link.

--- a/docs/exec-plans/completed/group-page-ui-refresh.md
+++ b/docs/exec-plans/completed/group-page-ui-refresh.md
@@ -11,6 +11,7 @@ Refresh reader group overview pages so the page reads as a visual story set hub 
 - Add a horizontal storyline flow section under the hero using the current group's primary storyline.
 - Include both primary group and reference items in the flow, with the current group highlighted.
 - Use the storyline title as the flow heading and mark reference items with an up-right cue.
+- Bound oversized storyline flows to the current group's neighborhood so synthetic operator pages do not render hundreds of cards.
 - Simplify story cards by removing the explicit `Open story` CTA and body readiness copy.
 - Hide internal story identifiers from story cards.
 
@@ -29,4 +30,5 @@ Refresh reader group overview pages so the page reads as a visual story set hub 
 ## Decision Log
 
 - The flow section uses the current group's primary storyline as the previous/next context.
+- Synthetic and other oversized storylines use a 24-card window around the current group for static export size and runtime performance.
 - Story cards remain navigable by making the full card a link.

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -69,6 +69,8 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - expanded regular storyline archive sections render `STORY_SET` primary groups and `BEFORE` / `AFTER` flow references in the same sorted one-column list; `NONE/NONE` review groups are `오퍼레이터 서사`, unmatched event groups are `미분류`, and `오퍼레이터 서사` is sorted last and rendered as a bottom section outside the main grid with an internal group grid
 - generated group and story metrics for total visible characters and estimated reading time
 - generated group-level images copied into `public/generated/group-backgrounds/`; manually curated `assets/group-backgrounds/<groupId>.png` files override inferred `ArknightsResource` sources, MAINLINE groups prefer square artwork, and ACTIVITY groups prefer wide atmospheric images
+- locale archive primary group cards render generated group artwork with a dark overlay, white titles, and compact Stories/chars/time metric badges
+- group overview pages place the title and Stories/chars/time metrics over the hero image, expose the named current storyline as horizontal group/reference cards, mark reference cards with an up-right cue, and make each story card itself the story link without visible internal story IDs
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
 - story pages keep `background` blocks in the flow as scroll markers with bundled preview images shown uncropped while the backdrop updates from IntersectionObserver visibility
 - story-page backdrop swaps are immediate; cross-fade state is intentionally omitted to keep the reader surface predictable

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -70,7 +70,7 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - generated group and story metrics for total visible characters and estimated reading time
 - generated group-level images copied into `public/generated/group-backgrounds/`; manually curated `assets/group-backgrounds/<groupId>.png` files override inferred `ArknightsResource` sources, MAINLINE groups prefer square artwork, and ACTIVITY groups prefer wide atmospheric images
 - locale archive primary group cards render generated group artwork with a dark overlay, white titles, and compact Stories/chars/time metric badges
-- group overview pages place the title and Stories/chars/time metrics over the hero image, expose the named current storyline as horizontal group/reference cards, mark reference cards with an up-right cue, and make each story card itself the story link without visible internal story IDs
+- group overview pages place the title and Stories/chars/time metrics over the hero image, expose the named current storyline as horizontal group/reference cards, bound oversized storylines to the current group neighborhood, mark reference cards with an up-right cue, and make each story card itself the story link without visible internal story IDs
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
 - story pages keep `background` blocks in the flow as scroll markers with bundled preview images shown uncropped while the backdrop updates from IntersectionObserver visibility
 - story-page backdrop swaps are immediate; cross-fade state is intentionally omitted to keep the reader surface predictable

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -308,6 +308,11 @@ test.describe("reader shell smoke", () => {
     await expect(mainStorylineItemList).toHaveCSS("flex-direction", "column");
     await expect(mainPrimaryRow).toBeVisible();
     await expect(mainPrimaryRow).toHaveAttribute("href", `/ark-str/reader/kr/${koreanMainStorylinePrimary.groupId}/`);
+    await expect(mainPrimaryRow.getByTestId("storyline-primary-card-title")).toHaveCSS(
+      "color",
+      "rgb(255, 255, 255)",
+    );
+    await expect(mainPrimaryRow.getByTestId("storyline-primary-card-metrics").locator("span")).toHaveCount(3);
     await expect(mainPrimaryRow).toContainText("stories");
     await expect(mainPrimaryRow).toContainText("chars");
     await expect(mainPrimaryRow).not.toContainText("Open group");
@@ -335,6 +340,47 @@ test.describe("reader shell smoke", () => {
     );
     await expect(page.getByTestId("group-shell")).toBeVisible();
     await expect(page.getByTestId("group-stats")).toBeVisible();
+    await expect(page.getByTestId("group-flow-nav")).toBeVisible();
+    await expect(
+      page.locator(
+        `[data-testid="group-flow-card"][data-group-id="${sampleStory.groupId}"][data-current="true"]`,
+      ),
+    ).toBeVisible();
+    const sampleStoryCard = page.locator(
+      `[data-testid="group-story-card"][href="/ark-str/reader/${sampleStory.server}/${sampleStory.groupId}/${sampleStory.storyId}/"]`,
+    );
+    await expect(sampleStoryCard).toBeVisible();
+    await expect(sampleStoryCard.getByTestId("group-story-metrics")).toContainText("chars");
+    await expect(sampleStoryCard).not.toContainText(sampleStory.storyId);
+    await expect(page.getByTestId("group-shell")).not.toContainText("Open story");
+    await expect(page.getByTestId("group-shell")).not.toContainText("Bundled body ready");
+
+    await page.goto(toAppPath(`reader/kr/${koreanMainStorylinePrimary.groupId}`));
+    const mainGroupFlow = page.getByTestId("group-flow-nav");
+    await expect(mainGroupFlow).toBeVisible();
+    await expect(mainGroupFlow.getByRole("heading", { name: koreanMainStoryline.title })).toBeVisible();
+    await expect(mainGroupFlow).not.toContainText("Storyline flow");
+    const currentMainGroupFlowCard = mainGroupFlow.locator(
+      `[data-testid="group-flow-card"][data-group-id="${koreanMainStorylinePrimary.groupId}"][data-current="true"]`,
+    );
+    await expect(currentMainGroupFlowCard).toBeVisible();
+    await expect(currentMainGroupFlowCard.getByTestId("group-flow-card-title")).toHaveCSS(
+      "color",
+      "rgb(255, 255, 255)",
+    );
+    const currentMainGroupFlowImage = currentMainGroupFlowCard.getByTestId("group-flow-card-image");
+    if ((await currentMainGroupFlowImage.count()) > 0) {
+      await expect(currentMainGroupFlowImage).toBeVisible();
+      const currentMainGroupFlowImageOpacity = Number(
+        await currentMainGroupFlowImage.evaluate((node) => window.getComputedStyle(node).opacity),
+      );
+      expect(currentMainGroupFlowImageOpacity).toBeGreaterThanOrEqual(0.7);
+    }
+    const mainGroupFlowReferenceCard = mainGroupFlow.locator(
+      `[data-testid="group-flow-card"][data-group-id="${koreanMainStorylineReference.groupId}"][data-role="reference"]`,
+    ).first();
+    await expect(mainGroupFlowReferenceCard).toBeVisible();
+    await expect(mainGroupFlowReferenceCard.locator("svg")).toBeVisible();
 
     await page.goto(
       toAppPath(`reader/${sampleStory.server}/${sampleStory.groupId}/${sampleStory.storyId}`),

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -179,6 +179,13 @@ const koreanMainStorylineReference = koreanMainStoryline?.items.find(
 const koreanMainStorylinePrimary = koreanMainStoryline?.items.find(
   (item: { role: string; groupId: string }) => item.role === "primary" && item.groupId === "main_0",
 );
+const koreanOperatorStoryline = generatedIndex.storylines.find(
+  (storyline: { server: string; storylineId: string }) =>
+    storyline.server === "kr" && storyline.storylineId === "synthetic_operator_narratives",
+);
+const koreanOperatorStorylinePrimary = koreanOperatorStoryline?.items.find(
+  (item: { role: string }) => item.role === "primary",
+);
 
 if (!koreanMainStoryline) {
   throw new Error("The Korean reader archive must include the mainLine storyline.");
@@ -190,6 +197,14 @@ if (!koreanMainStorylineReference) {
 
 if (!koreanMainStorylinePrimary) {
   throw new Error("The Korean mainLine storyline must include main_0 as a primary group.");
+}
+
+if (!koreanOperatorStoryline) {
+  throw new Error("The Korean reader archive must include the operator narrative storyline.");
+}
+
+if (!koreanOperatorStorylinePrimary) {
+  throw new Error("The Korean operator narrative storyline must include at least one primary group.");
 }
 
 function toAppPath(route = "") {
@@ -381,6 +396,16 @@ test.describe("reader shell smoke", () => {
     ).first();
     await expect(mainGroupFlowReferenceCard).toBeVisible();
     await expect(mainGroupFlowReferenceCard.locator("svg")).toBeVisible();
+
+    await page.goto(toAppPath(`reader/kr/${koreanOperatorStorylinePrimary.groupId}`));
+    const operatorGroupFlow = page.getByTestId("group-flow-nav");
+    await expect(operatorGroupFlow.getByRole("heading", { name: koreanOperatorStoryline.title })).toBeVisible();
+    expect(await operatorGroupFlow.getByTestId("group-flow-card").count()).toBeLessThanOrEqual(24);
+    await expect(
+      operatorGroupFlow.locator(
+        `[data-testid="group-flow-card"][data-group-id="${koreanOperatorStorylinePrimary.groupId}"][data-current="true"]`,
+      ),
+    ).toBeVisible();
 
     await page.goto(
       toAppPath(`reader/${sampleStory.server}/${sampleStory.groupId}/${sampleStory.storyId}`),


### PR DESCRIPTION
Closes #78

Summary:
- Reworked group overview hero, storyline flow navigation, and simplified story cards.
- Applied dark image treatment and metric badges to locale archive group cards.
- Updated product/frontend docs and smoke coverage for the new UI contracts.

Verification:
- npm run verify