### PR TITLE
Fix reader scroll flicker performance

### DIFF
--- a/ark-str-web-app/src/components/layout/floating-app-bar.tsx
+++ b/ark-str-web-app/src/components/layout/floating-app-bar.tsx
@@ -44,7 +44,7 @@ export function FloatingAppBar({ model }: FloatingAppBarProps) {
 
   return (
     <div
-      className="sticky top-4 z-40 rounded-[var(--radius-xl)] border border-[var(--border)] bg-[var(--surface)]/78 px-4 py-3 shadow-[var(--shadow-md)] backdrop-blur-xl"
+      className="sticky top-4 z-40 rounded-[var(--radius-xl)] border border-[var(--border)] bg-[var(--surface)]/96 px-4 py-3 shadow-[var(--shadow-md)]"
       data-testid="floating-app-bar"
     >
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">

--- a/ark-str-web-app/src/components/ui/disclosure-card.tsx
+++ b/ark-str-web-app/src/components/ui/disclosure-card.tsx
@@ -70,8 +70,8 @@ export function DisclosureCard({
       <div
         aria-hidden={!isOpen}
         className={cn(
-          "grid overflow-hidden border-t transition-[grid-template-rows,opacity,border-color] duration-300 ease-out",
-          isOpen ? "border-[var(--border)] opacity-100" : "border-transparent opacity-0",
+          "grid overflow-hidden border-t transition-[grid-template-rows,border-color] duration-300 ease-out",
+          isOpen ? "border-[var(--border)]" : "border-transparent",
         )}
         data-state={isOpen ? "open" : "closed"}
         data-testid={panelTestId}

--- a/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
+++ b/ark-str-web-app/src/features/reader/ui/reader-story-shell.tsx
@@ -288,7 +288,7 @@ function StoryBackdrop({ backgroundPath }: { backgroundPath: string | null }) {
           <img
             alt=""
             aria-hidden="true"
-            className="absolute inset-0 h-full w-full object-cover object-center blur-xl"
+            className="absolute inset-0 h-full w-full object-cover object-center"
             data-testid="story-backdrop-image"
             src={backgroundPath}
           />
@@ -613,9 +613,15 @@ export function ReaderStoryShell({
       : initialBackgroundId;
 
   const handleBackgroundVisible = useCallback((backgroundId: string) => {
-    setActiveBackground({
-      storyId,
-      backgroundId,
+    setActiveBackground((current) => {
+      if (current.storyId === storyId && current.backgroundId === backgroundId) {
+        return current;
+      }
+
+      return {
+        storyId,
+        backgroundId,
+      };
     });
   }, [storyId]);
   const activeBackgroundPath = activeBackgroundId ? (backgroundPaths[activeBackgroundId] ?? null) : null;
@@ -676,7 +682,7 @@ export function ReaderStoryShell({
       <section className="relative z-10 grid gap-6">
         <div className="grid gap-6 xl:grid-cols-[260px_minmax(0,1fr)]">
           <aside className="grid gap-4 self-start xl:sticky xl:top-28">
-            <Card className="bg-[var(--surface)]/90 backdrop-blur-sm">
+            <Card className="bg-[var(--surface)]/96">
               <CardHeader>
                 <Badge variant="default" className="w-fit">
                   Group
@@ -751,7 +757,7 @@ export function ReaderStoryShell({
         </div>
 
         <section data-testid="story-summary-section">
-          <Card className="bg-[var(--surface)]/92 backdrop-blur-sm">
+          <Card className="bg-[var(--surface)]/96">
             <CardHeader>
               <Badge variant="default" className="w-fit">
                 Summary

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -22,13 +22,13 @@ The app should feel editorial, deliberate, and product-specific rather than like
 - reader session persistence for preferred locale and last visited story
 - app-level light/dark theme toggle persisted through the preferences feature
 - canonical locale archive routes, group overview routes, and direct story deep links
-- locale archives render generated storyline sections as animated collapsed grid cards; regular storyline cards stay inside the main grid as single cells whether closed or open, expanded regular sections keep a simple one-column list, and operator narratives sit in a separate bottom section with an internal grid
+- locale archives render generated storyline sections as collapsed grid cards with 300ms height-only disclosure animation; regular storyline cards stay inside the main grid as single cells whether closed or open, expanded regular sections keep a simple one-column list, and operator narratives sit in a separate bottom section with an internal grid
 - locale archive primary group cards use the same dark image treatment as group-flow cards, with white titles and Stories/chars/time metrics rendered as compact pill badges
 - first-pass story body rendering sourced from bundled story detail JSON
-- a restrained floating app bar shared by home, archive, group, and story routes
+- a restrained floating app bar shared by home, archive, group, and story routes without backdrop-filter effects
 - story pages with left-side group navigation, main reading column, bottom summary section, and a floating top button
 - group overview pages render title and Stories/chars/time metrics over the generated hero image, then show the named current storyline as horizontally scrollable group/reference cards before simplified story cards; oversized storylines are bounded to the current group neighborhood, reference cards carry an up-right cue, and story cards avoid exposing internal story IDs
-- story-only dynamic backdrops driven directly by intersecting bundled background blocks, while non-story pages keep the archive base background
+- story-only dynamic backdrops driven directly by intersecting bundled background blocks without fixed-layer blur, while non-story pages keep the archive base background
 - in-flow background blocks keep their own bundled image previews without cropping and still drive the fixed story backdrop
 - story backdrop swaps on story pages happen immediately without cross-fade state
 - the UI uses a sans-first type system and a tighter radius scale for more consistent modern chrome

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -26,9 +26,9 @@ This v1 does not include:
 - visual tone: editorial archive
 - typography: sans-first, with display and body tokens kept in the same modern family
 - surface language: restrained radii and compact chrome instead of pill-heavy cards
-- archive surfaces: locale archive pages use animated collapsed storyline grid cards that keep their grid cell when expanded, simple regular storyline item lists, thinner flow-reference links, generated group image washes, and a separate bottom operator narrative grid section
+- archive surfaces: locale archive pages use height-only animated collapsed storyline grid cards that keep their grid cell when expanded, simple regular storyline item lists, thinner flow-reference links, generated group image washes, and a separate bottom operator narrative grid section
 - group imagery: manually curated `assets/group-backgrounds/<groupId>.png` files override inferred sources; generated output is optimized WebP, MAINLINE images are treated as square contained title art, and ACTIVITY images are treated as wide atmospheric backgrounds
-- story surfaces: dynamic story backdrops switch behind the content from intersecting background blocks while in-flow background cards keep uncropped optimized WebP previews and dialogue cards prioritize body-first reading layouts
+- story surfaces: dynamic story backdrops switch behind the content from intersecting background blocks without blur/backdrop-filter effects, while in-flow background cards keep uncropped optimized WebP previews and dialogue cards prioritize body-first reading layouts
 - implementation base: shadcn-style shared primitives customized for this project
 - theme strategy: light and dark from the start
 - runtime rule: no remote fonts, assets, or scripts

--- a/docs/exec-plans/active/reader-flicker-performance.md
+++ b/docs/exec-plans/active/reader-flicker-performance.md
@@ -1,0 +1,40 @@
+# Reader Flicker Performance
+
+Status: active
+Issue: #84
+Branch: `issue-84-reader-flicker-performance`
+
+## Objective
+
+Remove disclosure fade flicker and reduce story-page scroll flicker across Safari and Chromium browsers.
+
+## Scope
+
+- Remove opacity fade from storyline disclosure panels while keeping the 300ms height animation.
+- Remove high-cost blur and backdrop-filter effects from sticky/fixed reader chrome.
+- Prevent duplicate active-background state updates while scrolling.
+- Add smoke coverage for the relevant CSS performance contracts.
+
+## Constraints
+
+- Keep dynamic story backdrops and in-flow background preview cards.
+- Do not change generated content or content pipeline outputs.
+- Keep runtime resources local and bundled.
+
+## Tasks
+
+- Update `DisclosureCard` to animate only layout rows and border state.
+- Update floating app bar and story surfaces to avoid backdrop-filter and fixed-image filter usage.
+- Dedupe story active-background state updates by story/background id.
+- Update smoke tests to assert no opacity disclosure transition, app-bar backdrop filter, or backdrop image filter.
+
+## Verification
+
+- `npm run app:typecheck`
+- `npm run app:lint`
+- `npm run smoke`
+- `npm run verify`
+
+## Decision Log
+
+- Treat the flicker as a whole-page compositing issue because the user observed it in Chrome and on the app bar, not only in Safari or only on the backdrop image.

--- a/docs/exec-plans/completed/reader-flicker-performance.md
+++ b/docs/exec-plans/completed/reader-flicker-performance.md
@@ -1,6 +1,6 @@
 # Reader Flicker Performance
 
-Status: active
+Status: completed
 Issue: #84
 Branch: `issue-84-reader-flicker-performance`
 
@@ -38,3 +38,10 @@ Remove disclosure fade flicker and reduce story-page scroll flicker across Safar
 ## Decision Log
 
 - Treat the flicker as a whole-page compositing issue because the user observed it in Chrome and on the app bar, not only in Safari or only on the backdrop image.
+
+## Outcome
+
+- Storyline disclosure panels keep their height animation but no longer fade opacity.
+- Floating app bar, story backdrop image, group nav card, and summary card avoid scroll-time blur/backdrop-filter compositing hotspots.
+- Story background observer updates no longer create a new state object for the same active story/background pair.
+- Smoke tests lock the no-opacity/no-filter rendering contract.

--- a/docs/product-specs/arknights-story-reader.md
+++ b/docs/product-specs/arknights-story-reader.md
@@ -68,7 +68,7 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - locale-scoped character alias observation storage under `ark-str:character-observations:v1`
 - explicit empty summary state until the summary-generation issue lands, rendered below the story body instead of in a side rail
 - a floating rounded app bar shared by home, locale archive, group, and story pages
-- locale archives group story sets by generated storyline metadata in initially collapsed animated grid cards that remain one main-grid cell whether closed or open before routing into dedicated group overview pages
+- locale archives group story sets by generated storyline metadata in initially collapsed grid cards with height-only 300ms disclosure animation that remain one main-grid cell whether closed or open before routing into dedicated group overview pages
 - expanded regular storyline archive sections render `STORY_SET` primary groups and `BEFORE` / `AFTER` flow references in the same sorted one-column list; `NONE/NONE` review groups are `오퍼레이터 서사`, unmatched event groups are `미분류`, and `오퍼레이터 서사` is sorted last and rendered as a bottom section outside the main grid with an internal group grid
 - generated group and story metrics for total visible characters and estimated reading time
 - generated group-level images copied into `public/generated/group-backgrounds/`; manually curated `assets/group-backgrounds/<groupId>.png` files override inferred `ArknightsResource` sources, MAINLINE groups prefer square artwork, and ACTIVITY groups prefer wide atmospheric images
@@ -77,6 +77,7 @@ This phase keeps the recovered reader shell and Pages deployment path stable whi
 - story pages keep the global archive feel, but only story pages add a dynamic fixed background backdrop sourced from in-flow `background` blocks
 - story pages keep `background` blocks in the flow as scroll markers with bundled preview images shown uncropped while the backdrop updates from IntersectionObserver visibility
 - story-page backdrop swaps are immediate; cross-fade state is intentionally omitted to keep the reader surface predictable
+- story-page fixed backdrops and floating app chrome avoid blur/backdrop-filter effects to prevent scroll-time compositor flicker
 - story pages place group story navigation on the left and a floating scroll-to-top action at the lower right
 - dialogue cards use a portrait-plus-header layout that gives the spoken text the full card width instead of a narrow side-by-side split
 - Doctor choice normalization no longer renders a nested "Shared response" section; predicates that reference every option are treated as post-choice continuation

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -453,15 +453,12 @@ test.describe("reader shell smoke", () => {
     const appBar = page.getByTestId("floating-app-bar");
     const appBarBackdropFilter = await appBar.evaluate((node) => {
       const styles = window.getComputedStyle(node);
-      return {
-        backdropFilter: styles.backdropFilter,
-        webkitBackdropFilter: styles.getPropertyValue("-webkit-backdrop-filter"),
-      };
+      return [
+        styles.backdropFilter,
+        styles.getPropertyValue("-webkit-backdrop-filter"),
+      ].filter(Boolean);
     });
-    expect(appBarBackdropFilter).toEqual({
-      backdropFilter: "none",
-      webkitBackdropFilter: "",
-    });
+    expect(appBarBackdropFilter.every((value) => value === "none")).toBe(true);
     await expect(appBar.getByRole("link", { name: "스토리" })).toHaveAttribute(
       "href",
       `/ark-str/reader/${sampleStory.server}/`,

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -320,6 +320,10 @@ test.describe("reader shell smoke", () => {
       (node) => window.getComputedStyle(node).transitionDuration,
     );
     expect(panelTransitionDuration).toContain("0.3s");
+    const panelTransitionProperty = await mainStorylinePanel.evaluate(
+      (node) => window.getComputedStyle(node).transitionProperty,
+    );
+    expect(panelTransitionProperty).not.toContain("opacity");
     const mainStorylineItemList = mainStorylineSection.getByTestId("storyline-item-list");
     await expect(mainStorylineItemList).toHaveCSS("display", "flex");
     await expect(mainStorylineItemList).toHaveCSS("flex-direction", "column");
@@ -447,6 +451,17 @@ test.describe("reader shell smoke", () => {
     await expect(page.getByTestId("story-summary-section")).toBeVisible();
 
     const appBar = page.getByTestId("floating-app-bar");
+    const appBarBackdropFilter = await appBar.evaluate((node) => {
+      const styles = window.getComputedStyle(node);
+      return {
+        backdropFilter: styles.backdropFilter,
+        webkitBackdropFilter: styles.getPropertyValue("-webkit-backdrop-filter"),
+      };
+    });
+    expect(appBarBackdropFilter).toEqual({
+      backdropFilter: "none",
+      webkitBackdropFilter: "",
+    });
     await expect(appBar.getByRole("link", { name: "스토리" })).toHaveAttribute(
       "href",
       `/ark-str/reader/${sampleStory.server}/`,
@@ -534,6 +549,7 @@ test.describe("reader shell smoke", () => {
       "src",
       `${appBasePath}${generatedBackgrounds[sampleBackgroundIds[0]]}`,
     );
+    await expect(page.getByTestId("story-backdrop-image")).toHaveCSS("filter", "none");
 
     const secondBackgroundBlock = page
       .locator(`[data-testid="background-block"][data-background-id="${sampleBackgroundIds[1]}"]`)


### PR DESCRIPTION
## Summary
- remove opacity fade from storyline disclosure panels while keeping height animation
- remove blur/backdrop-filter compositor hotspots from floating app bar and story backdrop surfaces
- dedupe active story background state updates during scroll
- add smoke coverage for no-opacity/no-filter contracts

## Verification
- npm run app:typecheck
- npm run app:lint
- npm run smoke
- npm run verify

Closes #84