### PR TITLE
Fix home service section width and spacing

### DIFF
--- a/ark-str-web-app/src/app/globals.css
+++ b/ark-str-web-app/src/app/globals.css
@@ -142,10 +142,10 @@ body > * {
 }
 
 .home-full-bleed {
-  left: 50%;
   width: 100vw;
-  margin-left: -50vw;
-  margin-right: -50vw;
+  max-width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
 }
 
 a {

--- a/ark-str-web-app/src/features/bootstrap/ui/bootstrap-home.tsx
+++ b/ark-str-web-app/src/features/bootstrap/ui/bootstrap-home.tsx
@@ -422,7 +422,7 @@ export function BootstrapHome({
           </CardContent>
         </Card>
 
-        <Card className="mt-[13.5rem] bg-[var(--surface)]/94" data-testid="home-recommendations">
+        <Card className="mt-[8rem] bg-[var(--surface)]/94" data-testid="home-recommendations">
           <CardHeader className="gap-3">
             <div className="flex items-center gap-3">
               <LibraryBig className="h-5 w-5 text-[var(--accent)]" />

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -303,6 +303,19 @@ test.describe("reader shell smoke", () => {
     await expect(page.getByTestId("service-intro-icon")).toBeVisible();
     await expect(page.getByTestId("service-intro-section")).toContainText("ARK STR");
     await expect(page.getByTestId("service-intro-section")).toContainText("명일방주");
+    const serviceIntroBounds = await page.getByTestId("service-intro-section").evaluate((node) => {
+      const rect = node.getBoundingClientRect();
+
+      return {
+        left: rect.left,
+        width: rect.width,
+        viewportWidth: window.innerWidth,
+      };
+    });
+    expect(Math.abs(serviceIntroBounds.left)).toBeLessThanOrEqual(1);
+    expect(Math.abs(serviceIntroBounds.width - serviceIntroBounds.viewportWidth)).toBeLessThanOrEqual(
+      1,
+    );
     const homeViewportWidth = await page.evaluate(() => ({
       clientWidth: document.documentElement.clientWidth,
       scrollWidth: document.documentElement.scrollWidth,


### PR DESCRIPTION
Closes #94

## Summary
- Restore the ARK STR service intro section to true viewport-wide full bleed.
- Reduce the recommendation section top gap from 13.5rem to 8rem.
- Add smoke coverage for the full-bleed service intro bounds.

## Verification
- npm run verify